### PR TITLE
Fix --exclude options does not work correctly

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1041,9 +1041,12 @@ def input_dir(dirname, runner=None):
             message('directory ' + root)
         options.counters['directories'] += 1
         dirs.sort()
+        excluded_dirs = []
         for subdir in dirs:
             if excluded(subdir):
-                dirs.remove(subdir)
+                excluded_dirs.append(subdir)
+        for subdir in excluded_dirs:
+            dirs.remove(subdir)
         files.sort()
         for filename in files:
             if filename_match(filename) and not excluded(filename):


### PR DESCRIPTION
Hi,
I fixed problem about --exclude option:
It does not work for continuous excluded directories (second directory is not excluded).

examples:

   % find tests/ -type f
   tests/foo/invalid.py
   tests/foobar/bar/invalid.py
   % ./pep8.py -r --exclude foo,foobar tests
   tests/foobar/bar/invalid.py:2:1: E302 expected 2 blank lines, found 1
