### PR TITLE
Bugfix when running pep8.py in Jython 2.2.1

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -128,7 +128,7 @@ WHITESPACE_AROUND_OPERATOR_REGEX = \
 EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
 WHITESPACE_AROUND_NAMED_PARAMETER_REGEX = \
     re.compile(r'[()]|\s=[^=]|[^=!<>]=\s')
-
+LAMBDA_REGEX = re.compile(r'\blambda\b')
 
 WHITESPACE = ' \t'
 
@@ -661,7 +661,7 @@ def compound_statements(logical_line):
         before = line[:found]
         if (before.count('{') <= before.count('}') and  # {'a': 1} (dict)
             before.count('[') <= before.count(']') and  # [1:2] (slice)
-            not re.search(r'\blambda\b', before)):      # lambda x: x
+            not LAMBDA_REGEX.search(before)):           # lambda x: x
             return found, "E701 multiple statements on one line (colon)"
     found = line.find(';')
     if -1 < found:


### PR DESCRIPTION
Fixed issue when line decoding failed on Jython 2.2.1 (UnicodeDecodeError does not exist in Jython 2.2.1 and a UnicodeError is raised instead).

Also pre-compiled lambda regexp (fix for running in Jython as there are problems when the re module is imported in one thread and used at another one -- although in the general case it's also an optimization).
