### PR TITLE
Some fallout from the new E711/E712: SQLAlchemy expressions.

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -474,6 +474,7 @@ def continuation_line_indentation(logical_line, tokens, indent_level):
     indent_next = logical_line.endswith(':')
 
     indent_string = None
+    indent_any = []
     row = depth = 0
     # remember how many brackets were opened on each line
     parens = [0] * nrows
@@ -538,6 +539,9 @@ def continuation_line_indentation(logical_line, tokens, indent_level):
                 elif hang == 4 or not is_visual:
                     yield (start, 'E123 closing bracket does not match '
                            'indentation of opening bracket\'s line')
+            elif (start[1], text) in indent_any:
+                # token lined up with matching one from a previous line
+                pass
             elif is_visual:
                 # Visual indent is verified
                 for d1 in range(d, depth + 1):
@@ -576,6 +580,8 @@ def continuation_line_indentation(logical_line, tokens, indent_level):
                     indent[d] = set([i for i in indent[d] if i <= start[1]])
                     d -= 1
 
+            indent_any = []
+
         # look for visual indenting
         if ((parens[row] and token_type != tokenize.NL and
              hasattr(indent[depth], 'add')) and
@@ -591,6 +597,10 @@ def continuation_line_indentation(logical_line, tokens, indent_level):
                 indent_string = None
         elif token_type == tokenize.STRING:
             indent_string = start[1]
+
+        # let people line up tokens, if they truly must.
+        if token_type == tokenize.OP:
+            indent_any.append((start[1], text))
 
         # keep track of bracket depth
         if token_type == tokenize.OP:

--- a/testsuite/E12.py
+++ b/testsuite/E12.py
@@ -200,13 +200,3 @@ foo(1, 2, 3,
 #: E127
 foo(1, 2, 3,
              4, 5, 6)
-#: E127
-def unicode2html(s):
-    """Convert the characters &<>'" in string s to HTML-safe sequences.
-    Convert newline to <br> too."""
-    return unicode((s or '').replace('&', '&amp;')
-                            .replace('>', '&gt;')
-                            .replace('<', '&lt;')
-                            .replace("'", '&#39;')
-                            .replace('"', '&#34;')
-                            .replace('\n', '<br>\n'))

--- a/testsuite/E12not.py
+++ b/testsuite/E12not.py
@@ -356,14 +356,12 @@ action: """\
 def unicode2html(s):
     """Convert the characters &<>'" in string s to HTML-safe sequences.
     Convert newline to <br> too."""
-    return unicode((s or '')
-                   .replace('&', '&amp;')
-                   .replace('>', '&gt;')
-                   .replace('<', '&lt;')
-                   .replace("'", '&#39;')
-                   .replace('"', '&#34;')
-                   .replace('\n', '<br>\n'))
-
+    return unicode((s or '').replace('&', '&amp;')
+                            .replace('>', '&gt;')
+                            .replace('<', '&lt;')
+                            .replace("'", '&#39;')
+                            .replace('"', '&#34;')
+                            .replace('\n', '<br>\n'))
 
 #
 parser.add_option('--count', action='store_true',


### PR DESCRIPTION
The language in PEP8 around comparing to singletons is strong, but there
are examples of cases where '== False' has a distinct meaning from
'is False'.  Make this new rule only apply for control flow keywords that
that a boolean argument, which is what all the PEP8 examples are talking
about.
