### PR TITLE
Normalize keys in configuration file

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1737,7 +1737,7 @@ def read_config(options, args, arglist, parser):
         option_list = dict([(o.dest, o.type or o.action)
                             for o in parser.option_list if o.dest])
 
-        # First, read the defaut values
+        # First, read the default values
         options, _ = parser.parse_args([])
 
         # Second, parse the configuration


### PR DESCRIPTION
Use the same implicit rules used by optparse. This fixes issue #82.

This avoids confusion by allowing the user to use things like "max-line-length" or "--max-line-length" instead of being forced to use the implicit "max_line_length".
