### PR TITLE
Make sure the file exists before checking it

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1581,6 +1581,9 @@ class StyleGuide(object):
 
     def input_file(self, filename, lines=None, expected=None, line_offset=0):
         """Run all checks on a Python source file."""
+        if not os.path.exists(filename):
+            print('No such file found: %s' % filename)
+            return
         if self.options.verbose:
             print('checking %s' % filename)
         fchecker = Checker(filename, lines=lines, options=self.options)


### PR DESCRIPTION
Small patch to check that a file exists before running pep8 on it.

This prevents `pep8 whatever` to throw an exception that the file does not exists
