### PR TITLE
Show maximum length in "E501 line too long" error message

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -270,7 +270,8 @@ def maximum_line_length(physical_line, max_line_length):
                 pass
         if length > max_line_length:
             return max_line_length, \
-                "E501 line too long (%d characters)" % length
+                "E501 line too long (%d characters > max %d)" % \
+                (length, max_line_length)
 
 
 ##############################################################################


### PR DESCRIPTION
The error message is updated to include the maximum length of the
line.  This is useful when the user has specified a longer length
than the default using the --max-line-length option.
