### PR TITLE
 Allow exclude patterns to match directory paths.

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1625,11 +1625,11 @@ class StyleGuide(object):
         """
         Check if options.exclude contains a pattern that matches filename.
         """
-        basename = os.basename(filename)
-        return any(filename_match(filename, self.options.exclude,
-                                  default=False),
-                   filename_match(basename, self.options.exclude,
-                                  default=False))
+        basename = os.path.basename(filename)
+        return any((filename_match(filename, self.options.exclude,
+                                   default=False),
+                    filename_match(basename, self.options.exclude,
+                                   default=False)))
 
     def ignore_code(self, code):
         """


### PR DESCRIPTION
excluded strips down the filename to the basename, but fnmatch does not
need this, and it makes it impossible to trim a specific subdir path
in excludes that might need an additional layer of context (such as
"lib/python2.6") If we stop stripping down to basename for the check,
and then start joining root onto dirname in the os.path.walk call,
all works lovely.
