### PR TITLE
accept '-' as input filename to read data for checking from standard input

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1178,6 +1178,9 @@ class Checker(object):
         if filename is None:
             self.filename = 'stdin'
             self.lines = lines or []
+        elif filename == '-':
+            self.filename = 'stdin'
+            self.lines = stdin_get_value().splitlines(True)
         elif lines is None:
             try:
                 self.lines = readlines(filename)


### PR DESCRIPTION
We're currently integrating the pep8.py checker into PyCharm. PyCharm's inspections are typically run on unsaved files, and right now there is no good way to run pep8 on files without saving them to disk. This pull request adds the possibility to pass '-' as an input filename, in which case the text to scan is read from the standard input.
