### PR TITLE
Allow users to skip lines

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -264,6 +264,8 @@ def maximum_line_length(physical_line, max_line_length):
     line = physical_line.rstrip()
     length = len(line)
     if length > max_line_length:
+        if line.strip().lower().endswith('# nopep8'):
+            return
         if hasattr(line, 'decode'):   # Python 2
             # The line could contain multi-byte characters
             try:


### PR DESCRIPTION
This will disable pep8 for that line. It's simplistic but it works and it is
an elegant (and commonplace solution) to #27.

Tools like flake8 use `# NOQA` to skip PyFlakes errors when necessary,
coverage uses `# (No coverage)`, so I figured I'd leave this more generic
than was suggested in #27. Also this makes the patch a lot simpler since
we don't have to reparse the comment to ignore only a specific type of error
or warning.
