### PR TITLE
Fix --diff failing on one-line hunks

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -152,7 +152,7 @@ KEYWORD_REGEX = re.compile(r'(?:[^\s])(\s*)\b(?:%s)\b(\s*)' %
                            r'|'.join(KEYWORDS))
 OPERATOR_REGEX = re.compile(r'(?:[^\s])(\s*)(?:[-+*/|!<=>%&^]+)(\s*)')
 LAMBDA_REGEX = re.compile(r'\blambda\b')
-HUNK_REGEX = re.compile(r'^@@ -\d+,\d+ \+(\d+),(\d+) @@.*$')
+HUNK_REGEX = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@.*$')
 
 # Work around Python < 2.6 behaviour, which does not generate NL after
 # a comment which is on a line by itself.
@@ -1117,7 +1117,7 @@ def parse_udiff(diff, patterns=None, parent='.'):
                 nrows -= 1
             continue
         if line[:3] == '@@ ':
-            row, nrows = [int(g) for g in HUNK_REGEX.match(line).groups()]
+            row, nrows = [int(g or '1') for g in HUNK_REGEX.match(line).groups()]
             rv[path].update(range(row, row + nrows))
         elif line[:3] == '+++':
             path = line[4:].split('\t', 1)[0]


### PR DESCRIPTION
Without this fix, `pep8 --diff` fails uncleanly on diff hunks where either
the old or the new hunk is just one line and the patch omits the `,1`

Compact fix for jcrocholl#127 — there is another pull request for it but that's a little verbose
