### PR TITLE
Add new CLI options for skipping a number of lines at the beginning and end of a file from being checked

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1633,7 +1633,8 @@ class StyleGuide(object):
                 # contain a pattern that matches?
                 if ((filename_match(filename, filepatterns) and
                      not self.excluded(filename))):
-                    runner(os.path.join(root, filename))
+                    runner(os.path.join(root, filename),
+                           line_offset=self.options.skip_first_lines)
 
     def excluded(self, filename):
         """


### PR DESCRIPTION
I work with lots of Python code that resides in files where there is non-Python header and footer information in the files that is necessary for the larger system. These header and footer lines throw the pep8 checker off so I've added these CLI options that allow these lines to be ignored during the check. If the check is being run against a directory these options apply to all files found and checked.

New options:
--skip-first-lines=n
Prevents the first n lines of the file from being run through the checker. The line numbers are unaffected. If n=2 and there is an error on line 3 of the file pep8 will still report the error as being on line 3.

--skip-last-lines=n
Prevents the last n lines of the file from being run through the checker.
