### PR TITLE
Remove Python 3.1 from Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ python:
   - 2.5
   - 2.6
   - 2.7
-  - 3.1
   - 3.2
   - pypy
 install:


### PR DESCRIPTION
It is no longer [supported](https://github.com/travis-ci/travis-cookbooks/issues/89#issuecomment-10731833) by Travis CI. The `3.1` test is now falling back to `2.7`.
