### PR TITLE
pep8 and Org mode strings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,10 @@
 pep8 - Python style guide checker
 =================================
 
+  *This is a forked version, please use the original instead.  The only change
+  here is that, for avoiding E501 errors (line too long), the code considers
+  the visual length of Org links rather than their physical length.*
+
 pep8 is a tool to check your Python code against some of the style
 conventions in `PEP 8`_.
 

--- a/pep8.py
+++ b/pep8.py
@@ -226,6 +226,9 @@ def maximum_line_length(physical_line, max_line_length):
             except UnicodeError:
                 pass
         if length > max_line_length:
+            line = re.sub(r'\[\[[^]]*\]\[([^]]*)\]\]', r'\1', line)
+            length = len(line)
+        if length > max_line_length:
             return (max_line_length, "E501 line too long "
                     "(%d > %d characters)" % (length, max_line_length))
 


### PR DESCRIPTION
Hello, Johann.

The problem is when using Org mode for Python doc-strings or comments.  I made a small patch to pep8 so it considers the visual length of Org links rather than their physical length, as a last resort try before issuing E502 (line too long) diagnostic.

There is one problem to this, however.  Some valid Python code (like "[[1][0]]") might have the length wrongly computed as 1 while it should have been 8, weakening the pep8 program a bit in this area.

Surely, I would prefer not keeping a forked version of pep8. Do you have any opinion, advice, feeling on this?

Have a nice day!

François

P.S. The context is my https://github.com/pinard/poporg project.

P.P.S. Hmph!  Well, the README.rst change should not be considered.
