### PR TITLE
Fixes tox.ini testsuite typo

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ commands =
 	{envpython} pep8.py --testsuite testsuite
 	{envpython} pep8.py --statistics pep8.py
 	{envpython} pep8.py --doctest
-	{envpython} pep8.py -m testsuite.test_all
+	{envpython} -m testsuite.test_all
 
 [pep8]
 select =


### PR DESCRIPTION
Removed "pep8.py" from testsuite execution
