### PR TITLE
utf-8 BOM support

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1198,6 +1198,9 @@ class Checker(object):
                 self.lines = []
         else:
             self.lines = lines
+        bom = '\xEF\xBB\xBF'
+        if len(self.lines) and self.lines[0].startswith(bom):
+            self.lines[0] = self.lines[0][len(bom):]
         self.report = report or options.report
         self.report_error = self.report.error
 

--- a/testsuite/utf-8-bom.py
+++ b/testsuite/utf-8-bom.py
@@ -1,0 +1,6 @@
+﻿#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+
+hello = 'こんにちわ'
+
+# EOF


### PR DESCRIPTION
hi MR. jcrocholl

I'm japanease developper. I can speak poor english. 
I fix pep8.py. error in reading utf-8 bom python script file.

sometime, utf-8 text file specify byte order mark(BOM) at the begginings of file.
http://en.wikipedia.org/wiki/Unicode

before fix. this is utf-8 text file with BOM.

```
#/usr/bin/env python
```

pep8  say this error. becourse "#!" is not start at beggings of file.

```
1:4: E261 at least two spaces before inline comment
```

at the reading lines,check 3 byte of beggings of file. if it is BOM, remove it.

and add testsuite/utf-8-bom.py for tests.

regard.
