### PR TITLE
pep8 --diff also checks unmodified context

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1102,16 +1102,18 @@ def parse_udiff(diff, patterns=None, parent='.'):
     # For each file of the diff, the entry key is the filename,
     # and the value is a set of row numbers to consider.
     rv = {}
-    path = nrows = None
+    path = nrows = row = None
     for line in diff.splitlines():
         if nrows:
+            if line[:1] == '+':
+                rv[path].add(row)
             if line[:1] != '-':
                 nrows -= 1
+                row += 1
             continue
         if line[:3] == '@@ ':
             hunk_match = HUNK_REGEX.match(line)
             row, nrows = [int(g or '1') for g in hunk_match.groups()]
-            rv[path].update(range(row, row + nrows))
         elif line[:3] == '+++':
             path = line[4:].split('\t', 1)[0]
             if path[:2] == 'b/':


### PR DESCRIPTION
`pep8 --diff` doesn't only check modified code but also context which is a bad thing e.g. when using it in a git pre-commit hook.

Testcase to reproduce it:

**crap.py**

```
import sys

def foo( bar ):
    print "hello world"
    sys.exit (0)

def bar():
    pass


foo()
```

**crap2.py**

```
import sys

def foo( bar ):
    print "hello world"
    sys.exit (0)

def bar():
    print 'this function is not crap!'


foo()
```

**The resulting diff:**

```
--- crap.py     2013-06-25 14:34:36.677941391 +0200
+++ crap2.py    2013-06-25 14:34:39.366941926 +0200
@@ -5,7 +5,7 @@
     sys.exit (0)

 def bar():
-    pass
+    print 'this function is not crap!'


 foo()
```

**Output of `diff -u crap.py crap2.py | pep8 --diff`:**

```
./crap2.py:5:13: E211 whitespace before '('
./crap2.py:7:1: E302 expected 2 blank lines, found 1
```
