### PR TITLE
reverted "fix" for issue 203, added check for 214

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -431,6 +431,7 @@ def continued_indentation(logical_line, tokens, indent_level, hang_closing,
     if verbose >= 3:
         print(">>> " + tokens[0][4].rstrip())
 
+    last_token_multiline = False
     for token_type, text, start, end, line in tokens:
 
         newline = row < start[0] - first_row
@@ -538,7 +539,6 @@ def continued_indentation(logical_line, tokens, indent_level, hang_closing,
                 for idx in range(row, -1, -1):
                     if parens[idx]:
                         parens[idx] -= 1
-                        rel_indent[row] = rel_indent[idx]
                         break
             assert len(indent) == depth + 1
             if start[1] not in indent_chances:
@@ -547,7 +547,7 @@ def continued_indentation(logical_line, tokens, indent_level, hang_closing,
 
         last_token_multiline = (start[0] != end[0])
 
-    if indent_next and expand_indent(line) == indent_level + 4:
+    if indent_next and rel_indent[-1] == 4:
         yield (last_indent, "E125 continuation line does not distinguish "
                "itself from next logical line")
 
@@ -880,6 +880,7 @@ def explicit_line_join(logical_line, tokens):
     Okay: aaa = "bbb " \\n    "ccc"
     """
     prev_start = prev_end = parens = 0
+    backslash = None
     for token_type, text, start, end, line in tokens:
         if start[0] != prev_start and parens and backslash:
             yield backslash, "E502 the backslash is redundant between brackets"

--- a/testsuite/E12not.py
+++ b/testsuite/E12not.py
@@ -128,7 +128,7 @@ part = [-1, (2, 3,
 fnct(1, 2, 3,
      4, 5, 6)
 
-fnct(1, 2, 3
+fnct(1, 2, 3,
      4, 5, 6,
      7, 8, 9,
      10, 11)
@@ -568,14 +568,19 @@ result = some_function_that_takes_arguments('a', 'b', 'c',
 dica = {
     ('abc'
      'def'): (
-        'abc'),
+         'abc'),
 }
 
 (abcdef[0]
        [1]) = (
-    'abc')
+           'abc')
 
 ('abc'
  'def') == (
-    'abc')
+     'abc')
 #
+
+# issue 214
+bar(
+    1).zap(
+        2)


### PR DESCRIPTION
Addresses issue #214

reverts the "fix" for issue #203, which is a questionable change in itself (every editor I've ever seen, for instance, does not indent continuation lines that way.) but also broke very common patterns where all the indents are actually multiples of four.
