### PR TITLE
Allow disable of W601

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -951,7 +951,7 @@ def comparison_type(logical_line):
         yield match.start(), "E721 do not compare types, use 'isinstance()'"
 
 
-def python_3000_has_key(logical_line):
+def python_3000_has_key(logical_line, noqa):
     r"""
     The {}.has_key() method is removed in the Python 3.
     Use the 'in' operation instead.
@@ -959,6 +959,8 @@ def python_3000_has_key(logical_line):
     Okay: if "alph" in d:\n    print d["alph"]
     W601: assert d.has_key('alph')
     """
+    if noqa:
+        return
     pos = logical_line.find('.has_key(')
     if pos > -1:
         yield pos, "W601 .has_key() is deprecated, use 'in'"


### PR DESCRIPTION
Example library which uses the "has_key" method:

http://apt.alioth.debian.org/python-apt-doc/library/apt.cache.html#apt.cache.Cache.has_key

While has_key no longer exists for python 3, there are still libraries
which have this method and do not allow for 'key in dict'. This enables
the "nopep8/noqa" methods of disabling the warning per-line.

Signed-off-by: Sol Jerome sol.jerome@gmail.com
