### PR TITLE
setup: use `__import__('pep8').__version__` instead of function 'get_version'

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,13 +3,6 @@ from __future__ import with_statement
 from setuptools import setup
 
 
-def get_version():
-    with open('pep8.py') as f:
-        for line in f:
-            if line.startswith('__version__'):
-                return eval(line.split('=')[-1])
-
-
 def get_long_description():
     descr = []
     for fname in 'README.rst', 'CHANGES.txt':
@@ -18,9 +11,12 @@ def get_long_description():
     return '\n\n'.join(descr)
 
 
+version = __import__('pep8').__version__
+
+
 setup(
     name='pep8',
-    version=get_version(),
+    version=version,
     description="Python style guide checker",
     long_description=get_long_description(),
     keywords='pep8',


### PR DESCRIPTION
Motivated by https://github.com/jcrocholl/pep8/pull/221
