### PR TITLE
Fix #240: Allow errors on empty files

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,6 +5,7 @@ Changelog
 1.x (unreleased)
 ----------------
 
+* Allow the checkers to report errors on empty files. (Issue #240)
 * Fix ignoring too many checks when ``--select`` is used with codes
   declared in a flake8 extension. (Issue #216)
 

--- a/pep8.py
+++ b/pep8.py
@@ -1344,7 +1344,7 @@ class Checker(object):
         for name, cls, _ in self._ast_checks:
             checker = cls(tree, self.filename)
             for lineno, offset, text, check in checker.run():
-                if not noqa(self.lines[lineno - 1]):
+                if not self.lines or not noqa(self.lines[lineno - 1]):
                     self.report_error(lineno, offset, text, check)
 
     def generate_tokens(self):


### PR DESCRIPTION
The noqa check crashes when the file is empty. The soultion is to not
check for noqa when the file is empty -- if it's empty, the user might
not possibly put any #noqa comments in there.
