### PR TITLE
Local configuration files are ignored if `parse_argv` is False

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1838,6 +1838,8 @@ def process_options(arglist=None, parse_argv=False, config_file=None,
                 args = ['.']
             else:
                 parser.error('input not specified')
+        elif not args:
+            args = ['.']
         options = read_config(options, args, arglist, parser)
         options.reporter = parse_argv and options.quiet == 1 and FileReport
 


### PR DESCRIPTION
When using `pep8` as a library, there is currently no way to make the `StyleGuide` read local configuration files (`tox.ini`, `setup.cfg`) other than passing `parse_argv=True`. This makes little sense in library use where `sys.argv` is empty, since it [breaks for the case where no local configuration files exist](https://github.com/jcrocholl/pep8/blob/master/pep8.py#L1840) with "input not specified".
