### PR TITLE
StyleGuide accepts optional keyword argument arglist

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1571,11 +1571,12 @@ class StyleGuide(object):
     def __init__(self, *args, **kwargs):
         # build options from the command line
         self.checker_class = kwargs.pop('checker_class', Checker)
+        arglist = kwargs.pop('arglist', None)
         parse_argv = kwargs.pop('parse_argv', False)
         config_file = kwargs.pop('config_file', None)
         parser = kwargs.pop('parser', None)
         options, self.paths = process_options(
-            parse_argv=parse_argv, config_file=config_file, parser=parser)
+            arglist, parse_argv, config_file, parser)
         if args or kwargs:
             # build options from dict
             options_dict = dict(*args, **kwargs)


### PR DESCRIPTION
If given, arglist is passed on to process_options. This allows specifying a
non-empty argument list when using pep8 as a library where command line
arguments are not parsed.
