### PR TITLE
Handle broken pipe in check_files()

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -55,6 +55,7 @@ import time
 import inspect
 import keyword
 import tokenize
+import errno
 from optparse import OptionParser
 from fnmatch import fnmatch
 try:
@@ -1672,6 +1673,9 @@ class StyleGuide(object):
                     runner(path)
         except KeyboardInterrupt:
             print('... stopped')
+        except IOError as e:
+            if e.errno != errno.EPIPE:
+                raise e
         report.stop()
         return report
 


### PR DESCRIPTION
This way partial output (e.g. `pep8 . | head`) doesn't get clobbered with a
stacktrace on stderr.
# How to reproduce the problem

```
$ pep8 . | head
./nimdok.py:14:10: E251 unexpected spaces around keyword / parameter equals
./nimdok.py:15:10: E251 unexpected spaces around keyword / parameter equals
./nimdok.py:16:9: E251 unexpected spaces around keyword / parameter equals
./nimdok.py:18:14: E251 unexpected spaces around keyword / parameter equals
./nimdok.py:21:14: E251 unexpected spaces around keyword / parameter equals
./nimdok.py:21:80: E501 line too long (91 > 79 characters)
./nimdok.py:22:11: E251 unexpected spaces around keyword / parameter equals
./nimdok.py:23:1: E122 continuation line missing indentation or outdented
./nimdok.py:27:1: E302 expected 2 blank lines, found 1
./nimdok.py:32:1: E302 expected 2 blank lines, found 1
Traceback (most recent call last):
  File "/usr/local/bin/pep8", line 9, in <module>
    load_entry_point('pep8==1.4.6', 'console_scripts', 'pep8')()
  File "/usr/local/lib/python2.7/site-packages/pep8.py", line 1863, in _main
    report = pep8style.check_files()
  File "/usr/local/lib/python2.7/site-packages/pep8.py", line 1622, in check_files
    self.input_dir(path)
  File "/usr/local/lib/python2.7/site-packages/pep8.py", line 1658, in input_dir
    runner(os.path.join(root, filename))
  File "/usr/local/lib/python2.7/site-packages/pep8.py", line 1636, in input_file
    return fchecker.check_all(expected=expected, line_offset=line_offset)
  File "/usr/local/lib/python2.7/site-packages/pep8.py", line 1408, in check_all
    return self.report.get_file_results()
  File "/usr/local/lib/python2.7/site-packages/pep8.py", line 1539, in get_file_results
    'code': code, 'text': text,
IOError: [Errno 32] Broken pipe
```
