### PR TITLE
Allow comments to start with multiple `#` signs

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -797,7 +797,8 @@ def whitespace_before_comment(logical_line, tokens):
                     yield (prev_end,
                            "E261 at least two spaces before inline comment")
             symbol, sp, comment = text.partition(' ')
-            bad_prefix = symbol not in ('#', '#:')
+            cnt = symbol.count('#')
+            bad_prefix = symbol not in ('#' * cnt, '%s:' % '#' * cnt)
             if inline_comment:
                 if bad_prefix or comment[:1].isspace():
                     yield start, "E262 inline comment should start with '# '"


### PR DESCRIPTION
This is valid pep8 as long as they are followed by a space

Fixes https://github.com/jcrocholl/pep8/issues/270
