### PR TITLE
Fixed #281 in docs

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -158,7 +158,8 @@ Configuration
 
 The behaviour may be configured at two levels.
 
-The user settings are read from the ``~/.config/pep8`` file.
+The user settings are read from the ``~/.config/pep8`` file and 
+for Windows from the ``~\.pep8`` file.
 Example::
 
   [pep8]


### PR DESCRIPTION
Updated the Configuration section of the Intro Documentation to tell Windows users where their .pep8 configuration file is stored.
