### PR TITLE
Always open files with universal newline flag

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1037,7 +1037,7 @@ if '' == ''.encode():
     # Python 2: implicit encoding.
     def readlines(filename):
         """Read the source code."""
-        with open(filename) as f:
+        with open(filename, 'rU') as f:
             return f.readlines()
     isidentifier = re.compile(r'[a-zA-Z_]\w*').match
     stdin_get_value = sys.stdin.read


### PR DESCRIPTION
Sometimes we need to lint files with Mac OS 9 line endings "\r". This is very sad, but true.

In this case pep8 works not correctly: it reads whole file as one line and every error has "line 1" location and it's always says about "line too long":

```
foo.py:1:80: E501 line too long (3284 > 79 characters)
```

It is even throw exceptions sometimes:

```
Traceback (most recent call last):
  File "/Users/rudnyh/work/.venv/pep8-test/bin/flake8", line 9, in <module>
    load_entry_point('flake8==2.1.0', 'console_scripts', 'flake8')()
  File "/Users/rudnyh/work/.venv/pep8-test/lib/python2.7/site-packages/flake8/main.py", line 32, in main
    report = flake8_style.check_files()
  File "/Users/rudnyh/work/.venv/pep8-test/lib/python2.7/site-packages/pep8.py", line 1672, in check_files
    runner(path)
  File "/Users/rudnyh/work/.venv/pep8-test/lib/python2.7/site-packages/flake8/engine.py", line 73, in input_file
    return fchecker.check_all(expected=expected, line_offset=line_offset)
  File "/Users/rudnyh/work/.venv/pep8-test/lib/python2.7/site-packages/pep8.py", line 1410, in check_all
    self.check_ast()
  File "/Users/rudnyh/work/.venv/pep8-test/lib/python2.7/site-packages/pep8.py", line 1360, in check_ast
    if not self.lines or not noqa(self.lines[lineno - 1]):
IndexError: list index out of range
```

Here is docs about universal newlines mode in Python 2: https://docs.python.org/2/library/functions.html#open
Universal newlines mode in Python 3 is deprecated: https://docs.python.org/3/library/functions.html#open so I only add this option to Python 2 'open' call.

This fix (adding "universal newlines mode" to "open" function for Python 2) works fine for me, but it would be nice, if anyone could check it.
