### PR TITLE
Adds --double-indent

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1758,8 +1758,8 @@ def get_parser(prog='pep8', version=__version__):
                           usage="%prog [options] input ...")
     parser.config_options = [
         'exclude', 'filename', 'select', 'ignore', 'max-line-length',
-        'hang-closing', 'count', 'format', 'quiet', 'show-pep8',
-        'show-source', 'statistics', 'verbose']
+        'hang-closing', 'double-indent', 'count', 'format', 'quiet',
+        'show-pep8', 'show-source', 'statistics', 'verbose']
     parser.add_option('-v', '--verbose', default=0, action='count',
                       help="print status messages, or debug with -vv")
     parser.add_option('-q', '--quiet', default=0, action='count',


### PR DESCRIPTION
PEP 8 states that hanging continuation lines should be indented once, except for blocks (if/def/with/...):

``` python
somefunc(
    "foo",
    "bar")

def somefunc(
        param1,
        param2):
    pass

if (someconditionhere and
        someothercondition):
    pass
```

However, it is pretty common (ALTHOUGH NON PEP8 COMPLIANT) to indent twice everywhere instead, eg:

``` python
lastfunciswear(
        "foo",
        "bar")
```

Without --double-indent, this would trigger E126. Disabling E126 would also stop pep8 from reporting errors like 9-space indents.
