### PR TITLE
Fixing compound_statement not to be quadratic in # of :s

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -866,18 +866,21 @@ def compound_statements(logical_line):
     line = logical_line
     last_char = len(line) - 1
     found = line.find(':')
+    prev_found = 0
+    counts = dict((char, 0) for char in '{}[]()')
     while -1 < found < last_char:
-        before = line[:found]
-        if ((before.count('{') <= before.count('}') and   # {'a': 1} (dict)
-             before.count('[') <= before.count(']') and   # [1:2] (slice)
-             before.count('(') <= before.count(')'))):    # (annotation)
-            if LAMBDA_REGEX.search(before):
+        update_counts(line[prev_found:found], counts)
+        if ((counts['{'] <= counts['}'] and   # {'a': 1} (dict)
+             counts['['] <= counts[']'] and   # [1:2] (slice)
+             counts['('] <= counts[')'])):    # (annotation)
+            if LAMBDA_REGEX.search(line, 0, found):
                 yield 0, "E731 do not assign a lambda expression, use a def"
                 break
-            if before.startswith('def '):
+            if line.startswith('def '):
                 yield 0, "E704 multiple statements on one line (def)"
             else:
                 yield found, "E701 multiple statements on one line (colon)"
+        prev_found = found
         found = line.find(':', found + 1)
     found = line.find(';')
     while -1 < found:
@@ -1173,6 +1176,14 @@ def filename_match(filename, patterns, default=True):
     if not patterns:
         return default
     return any(fnmatch(filename, pattern) for pattern in patterns)
+
+
+def update_counts(s, counts):
+    r"""Adds one to the counts of each appearence of characters in s,
+        for characters in counts"""
+    for char in s:
+        if char in counts:
+            counts[char] += 1
 
 
 if COMMENT_WITH_NL:


### PR DESCRIPTION
`compound_statement` is quadratic in term of # of colons included in a line
This can be problematic for things like generated dictionaries.
I've made it not to be quadratic anymore.