### PR TITLE
Makes pep8 pluggable

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1207,11 +1207,14 @@ def init_checks_registry():
 
     The first argument name is either 'physical_line' or 'logical_line'.
     """
+    # Load from this module
+    # This module is not mentioned in its own setup.py so that it works as
+    # expected stand-alone (or when running the testsuite)
+    register_from_module(inspect.getmodule(register_check))
     try:
         from pkg_resources import iter_entry_points
     except ImportError:
-        # No pkg_resources -- use the old behavior, load from this module only
-        register_from_module(inspect.getmodule(register_check))
+        pass
     else:
         # pkg_resources is available -- load from 'pep8.checks' entry point
         for entry_point in iter_entry_points('pep8.checks'):

--- a/setup.py
+++ b/setup.py
@@ -40,9 +40,6 @@ setup(
         'console_scripts': [
             'pep8 = pep8:_main',
         ],
-        'pep8.checks': [
-            'builtin = pep8:filename_match',
-        ],
     },
     classifiers=[
         'Development Status :: 5 - Production/Stable',


### PR DESCRIPTION
This follows up on #294. It adds a proper way to extend pep8 through plugins.

Looks like I've had this lying around for a while.
