### PR TITLE
Fix: self.counters need to be initialized

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1485,8 +1485,8 @@ class BaseReport(object):
         # Results
         self.elapsed = 0
         self.total_errors = 0
-        self.counters = dict.fromkeys(self._benchmark_keys, 0)
         self.messages = {}
+        self.init_counters()
 
     def start(self):
         """Start the timer."""
@@ -1495,6 +1495,9 @@ class BaseReport(object):
     def stop(self):
         """Stop the timer."""
         self.elapsed = time.time() - self._start_time
+
+    def init_counters(self):
+        self.counters = dict.fromkeys(self._benchmark_keys, 0)
 
     def init_file(self, filename, lines, expected, line_offset):
         """Signal a new file."""
@@ -1583,6 +1586,7 @@ class StandardReport(BaseReport):
     def init_file(self, filename, lines, expected, line_offset):
         """Signal a new file."""
         self._deferred_print = []
+        self.init_counters()
         return super(StandardReport, self).init_file(
             filename, lines, expected, line_offset)
 


### PR DESCRIPTION
When i use `--first`:

```
$python pep8.py --first testsuite/utf-8.py
testsuite/utf-8.py:43:80: E501 line too long (80 > 79 characters)
```

but when i check current directory:

```
$python pep8.py --first
...
./testsuite/E90.py:9:2: E901 IndentationError: unindent does not match any outer indentation level
./testsuite/W29.py:7:1: W293 blank line contains whitespace
./testsuite/W60.py:2:5: W601 .has_key() is deprecated, use 'in'
./testsuite/W60.py:5:17: W602 deprecated form of raising exception
./testsuite/W60.py:12:6: W603 '<>' is deprecated, use '!='
./testsuite/W60.py:15:7: W604 backticks are deprecated, use 'repr()'
```

the `testsuite/utf-8.py` is no displayed. i found the self.counters has not been initialized, `E501`  has counted before
