### PR TITLE
Fix normalize_paths to allow whitespace

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1155,10 +1155,13 @@ def normalize_paths(value, parent=os.curdir):
 
     Return a list of absolute paths.
     """
-    if not value or isinstance(value, list):
+    if not value:
+        return []
+    if isinstance(value, list):
         return value
     paths = []
     for path in value.split(','):
+        path = path.strip()
         if '/' in path:
             path = os.path.abspath(os.path.join(parent, path))
         paths.append(path.rstrip('/'))

--- a/testsuite/test_all.py
+++ b/testsuite/test_all.py
@@ -46,12 +46,13 @@ class Pep8TestCase(unittest.TestCase):
 
 
 def suite():
-    from testsuite import test_api, test_shell
+    from testsuite import test_api, test_shell, test_util
 
     suite = unittest.TestSuite()
     suite.addTest(unittest.makeSuite(Pep8TestCase))
     suite.addTest(unittest.makeSuite(test_api.APITestCase))
     suite.addTest(unittest.makeSuite(test_shell.ShellTestCase))
+    suite.addTest(unittest.makeSuite(test_util.UtilTestCase))
     return suite
 
 

--- a/testsuite/test_util.py
+++ b/testsuite/test_util.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+import os
+import unittest
+
+import pep8
+
+
+class UtilTestCase(unittest.TestCase):
+    def test_normalize_paths(self):
+        cwd = os.getcwd()
+
+        self.assertEquals(pep8.normalize_paths(''), [])
+        self.assertEquals(pep8.normalize_paths(['foo']), ['foo'])
+        self.assertEquals(pep8.normalize_paths('foo'), ['foo'])
+        self.assertEquals(pep8.normalize_paths('foo,bar'), ['foo', 'bar'])
+        self.assertEquals(pep8.normalize_paths('/foo/bar,baz/../bat'),
+                          ['/foo/bar', cwd + '/bat'])
+        self.assertEquals(pep8.normalize_paths(".pyc,\n   build/*"),
+                          ['.pyc', cwd + '/build/*'])


### PR DESCRIPTION
This fixes normalize_paths so that it strips whitespace before and after
paths before working on them. This allows you to do specify excludes
with multiple lines in the config file.

This also tweaks normalize_paths so that the behavior matches the
docstring.

This also adds tests.

Fixes #339
