### PR TITLE
Fix non-ascii characters continued indentation

### DIFF
--- a/testsuite/E12.py
+++ b/testsuite/E12.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 #: E121
 print "E121", (
   "dent")
@@ -39,9 +40,11 @@ print "E128", ("visual",
 #: E128
 print "E128", ("under-",
               "under-indent")
-#:
-
-
+#: E128
+some_characters = [
+    (('测试', 38), [('테스트', 39),
+    |             ('тест', 40)])
+]
 #: E126
 my_list = [
     1, 2, 3,
@@ -307,6 +310,11 @@ foo(1, 2, 3,
 #: E127
 foo(1, 2, 3,
              4, 5, 6)
+#: E127
+some_characters = [
+    (('测试', 38), [('테스트', 39),
+                     ('тест', 40)])
+]
 #: E128 E128
 if line_removed:
     self.event(cr, uid,

--- a/testsuite/E12not.py
+++ b/testsuite/E12not.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 if (
         x == (
             3
@@ -642,3 +643,16 @@ print dedent(
         # more stuff
     )
 )
+
+some_special_characters = [
+    (('测试一下', 38), [('테스트', 39),
+                        ('тест', 40),
+                        ('test this': 41)])
+]
+
+some_characters = [
+    (
+        ('测试', 38), [
+            ('테트', 39),
+            ('тест', 40)])
+]


### PR DESCRIPTION
I have 2 files for this:

```python
$cat ascii.py
story_tags = [
    (('xxxxxx', 38), [('xxxx', 39),
                      ('xxxx', 40)]),
]
```
and

```python
$cat non-ascii.py
story_tags = [
    (('数码产品', 38), [('手机', 39),
                       ('配件', 40)])
]
```

They look the same format, but the result was different:

```python
$pep8 ascii.py

$pep8 non-ascii.py
non-ascii.py:3:25: E128 continuation line under-indented for visual indent
```
Because:

```python
In [1]: len('xxxx')
Out[1]: 4

In [2]: len('数码')
Out[2]: 6
```

They look same width. But the length is different 