### PR TITLE
Do not enforce whitespaces around ** operator; issue #292

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,8 @@ Changes:
 
 * Report E402 for import statements not at the top of the file. (Issue #264)
 
+* Do not enforce whitespaces around ``**`` operator. (Issue #292)
+
 * Strip whitespace from around paths during normalization. (Issue #339 / #343)
 
 * Update ``--format`` documentation. (Issue #198 / Pull Request #310)

--- a/pep8.py
+++ b/pep8.py
@@ -688,7 +688,7 @@ def missing_whitespace_around_operator(logical_line, tokens):
                 if need_space is True or need_space[1]:
                     # A needed trailing space was not found
                     yield prev_end, "E225 missing whitespace around operator"
-                else:
+                elif prev_text != '**':
                     code, optype = 'E226', 'arithmetic'
                     if prev_text == '%':
                         code, optype = 'E228', 'modulo'

--- a/testsuite/E22.py
+++ b/testsuite/E22.py
@@ -89,7 +89,7 @@ c = (a+ b)*(a - b)
 #:
 
 #: E226
-z = 2**30
+z = 2//30
 #: E226 E226
 c = (a+b) * (a-b)
 #: E226
@@ -103,8 +103,8 @@ hypot2 = x*x + y*y
 #: E226
 c = (a + b)*(a - b)
 #: E226
-def squares(n):
-    return (i**2 for i in range(n))
+def halves(n):
+    return (i//2 for i in range(n))
 #: E227
 _1kB = _1MB>>10
 #: E227
@@ -129,7 +129,8 @@ submitted += 1
 x = x * 2 - 1
 hypot2 = x * x + y * y
 c = (a + b) * (a - b)
-_1MB = 2 ** 20
+_1MiB = 2 ** 20
+_1TiB = 2**30
 foo(bar, key='word', *args, **kwargs)
 baz(**kwargs)
 negative = -1
@@ -140,7 +141,6 @@ func2(lambda a, b=h[:], c=0: (a, b, c))
 if not -5 < x < +5:
     print >>sys.stderr, "x is out of range."
 print >> sys.stdout, "x is an integer."
-z = 2 ** 30
 x = x / 2 - 1
 
 if alpha[:-i]:
@@ -148,7 +148,7 @@ if alpha[:-i]:
 
 
 def squares(n):
-    return (i ** 2 for i in range(n))
+    return (i**2 for i in range(n))
 
 ENG_PREFIXES = {
     -6: "\u03bc",  # Greek letter mu


### PR DESCRIPTION
Always accept both `a ** 2 + b ** 2` and `a**2 + b**2`.

Rationale: `**` is the highest priority operator, issue #292
