### PR TITLE
Python2 now detects encoding according to PEP263

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -55,12 +55,11 @@ import inspect
 import keyword
 import tokenize
 import codecs
-import io
-from io import TextIOWrapper
 from optparse import OptionParser
 from fnmatch import fnmatch
 try:
     from configparser import RawConfigParser
+    from io import TextIOWrapper
 except ImportError:
     from ConfigParser import RawConfigParser
 
@@ -1199,8 +1198,8 @@ def detect_encoding(readline):
     bom_found = False
     encoding = None
     default = 'utf-8'
-    BOM_UTF8 = b'\xef\xbb\xbf'
-    blank_re = re.compile(br'^[ \t\f]*(?:[#\r\n]|$)')
+    BOM_UTF8 = '\xef\xbb\xbf'
+    blank_re = re.compile('^[ \\t\\f]*(?:[#\\r\\n]|$)')
 
     def get_normal_name(orig_enc):
         """Imitates get_normal_name in tokenizer.c."""
@@ -1217,7 +1216,7 @@ def detect_encoding(readline):
         try:
             return readline()
         except StopIteration:
-            return b''
+            return ''
 
     def find_cookie(line):
         cookie_re = re.compile(r'^[ \t\f]*#.*coding[:=][ \t]*([-\w.]+)')
@@ -1289,11 +1288,11 @@ is_python2 = '' == ''.encode()
 def readlines(filename):
     """Read the source code."""
     try:
-        with io.open(filename, 'rb') as f:
+        with open(filename, 'rb') as f:
             (coding, lines) = detect_encoding(f.readline) if is_python2 \
                 else tokenize.detect_encoding(f.readline)
-            f = TextIOWrapper(f, coding, line_buffering=True)
-            return [l.decode(coding) for l in lines] + f.readlines()
+            return [l.decode(coding) for l in lines] + \
+                   [l.decode(coding) for l in f.readlines()]
     except (LookupError, SyntaxError, UnicodeError):
         # Fall back if file encoding is improperly declared
         with open(filename, 'rU') if is_python2 \

--- a/testsuite/shift-jis.py
+++ b/testsuite/shift-jis.py
@@ -1,0 +1,7 @@
+# -*- coding: shift-jis -*-
+#: Okay
+_EPSILON = {'pressao': {'psig': 1,
+                        'kPag': 5},
+            'press‚²ƒL': {'psig': 1,
+                        'kPag': 5},
+            }

--- a/testsuite/utf-8.py
+++ b/testsuite/utf-8.py
@@ -50,3 +50,9 @@ class Rectangle(Blob):
 # 3 narrow chars (Na) + 77 wide chars (W)
 # 情 情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情情
 #
+#: Okay
+_EPSILON = {'pressao': {'psig': 1,
+                        'kPag': 5},
+            'pressão': {'psig': 1,
+                        'kPag': 5},
+            }


### PR DESCRIPTION
This adds support for detecting source file encoding as defined in PEP263 in Python2.
- inlined python's 3 codecs.detect_encoding to make python2 recognize
  PEP 263 encodings the same way as the python3 implementation does
- simplified readlines implementation a little bit, to share the code
  between 2 and 3
- added the test case mentioned in the issue, and a shift-jis variant
- build passing at https://travis-ci.org/miszobi/pep8/builds/55316861
- fixes #391 
