### PR TITLE
Allow "empty" file to have a \n character

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -189,7 +189,7 @@ def trailing_blank_lines(physical_line, lines, line_number, total_lines):
     """
     if line_number == total_lines:
         stripped_last_line = physical_line.rstrip()
-        if not stripped_last_line:
+        if not stripped_last_line and line_number != 1:
             return 0, "W391 blank line at end of file"
         if stripped_last_line == physical_line:
             return len(physical_line), "W292 no newline at end of file"


### PR DESCRIPTION
W292 and W391 are conflicting when it comes to "empty" files. Normally empty files are not that useful. However in Python, it's often useful to have an empty `__init__.py` to declare a folder as a package without necessarily putting any logic there (In a perfect world those file would contain a docstring).

We could debate whether or not an "empty" file should contain a `\n` or not. However, I don't see any real practical implication and think pep8 should simply accept both.
