### PR TITLE
Allow spaces after tabs for alignment

### DIFF
--- a/testsuite/E10.py
+++ b/testsuite/E10.py
@@ -3,6 +3,11 @@ for a in 'abc':
     for b in 'xyz':
         print a  # indented with 8 spaces
 	print b  # indented with 1 tab
+#: E101:4:2 W191 W191 W191
+if True:
+	foo(
+		bar(baz),
+	        eek)
 #: E101 E122 W191 W191
 if True:
 	pass
@@ -25,12 +30,7 @@ class TestP4Poller(unittest.TestCase):
 
     def tearDown(self):
         pass
-
 #
-#: E101 W191 W191
-if True:
-	foo(1,
-	    2)
 #: E101 E101 W191 W191
 def test_keys(self):
     """areas.json - All regions are accounted for."""

--- a/testsuite/W19.py
+++ b/testsuite/W19.py
@@ -52,6 +52,11 @@ def long_function_name(
         var_one, var_two, var_three,
         var_four):
 	print(var_one)
+#: W191
+if True:
+	print "indent set to tabs"
+foo = long_function_name(var_one, var_two,
+                         var_three, var_four)
 #: E101 W191
 if ((row < 0 or self.moduleCount <= row or
      col < 0 or self.moduleCount <= col)):
@@ -93,14 +98,14 @@ if length > options.max_line_length:
 
 
 #
-#: E101 W191 W191
+#: W191 W191
 if os.path.exists(os.path.join(path, PEP8_BIN)):
 	cmd = ([os.path.join(path, PEP8_BIN)] +
 	       self._pep8_options(targetfile))
 #: W191
 '''
 	multiline string with tab in it'''
-#: E101 W191
+#: W191
 '''multiline string
 	with tabs
    and spaces
@@ -131,6 +136,10 @@ if True:
 	foo(
 		1,
 		2)
+#: W191 W191
+if True:
+	foo(1,
+	    2)
 #: W191 W191 W191 W191 W191
 def test_keys(self):
 	"""areas.json - All regions are accounted for."""

--- a/testsuite/test_api.py
+++ b/testsuite/test_api.py
@@ -252,8 +252,8 @@ class APITestCase(unittest.TestCase):
         pep8style = pycodestyle.StyleGuide(paths=[E11])
 
         # Default lists of checkers
-        self.assertTrue(len(pep8style.options.physical_checks) > 4)
-        self.assertTrue(len(pep8style.options.logical_checks) > 10)
+        self.assertTrue(len(pep8style.options.physical_checks) > 3)
+        self.assertTrue(len(pep8style.options.logical_checks) > 11)
         self.assertEqual(len(pep8style.options.ast_checks), 0)
 
         # Sanity check


### PR DESCRIPTION
First off, thanks for writing pep8!  It's very useful.

We've got a large code base that uses all tabs.  I'm a bit pedantic when it comes to indentation, so I like to make sure that my hanging indents line up at any tab width by aligning them with spaces after the tabs.  For example:

    if True:
        long_name(foo, bar,  # imagine this is indented with one tab
                  baz)       # this is indented with one tab plus ten spaces

Mixing spaces and tabs like this means that, despite using the hated tabs for indentation, you get properly lined-up code no matter what width people use for displaying tabs.

Python has no problem with this since it's mixed spaces and tabs inside parentheses.  pep8, though, wasn't able to make that distinction with its physical line check.  My commit thus replaces the physical check for E101, mixed tabs and spaces, with a logical line check.  Using a logical line check made it easier to examine the context, to know when mixed tabs and spaces should be permitted.

PEP 8 says, "Hanging indents \*may\* be indented to other than 4 spaces." However pep8's code and tests don't seem to permit this, so my replacement check doesn't permit it either.  For example, pep8 still gives "E101 indentation contains mixed tabs and spaces" on the last line here:

    if True:
        foo()   # imagine these two lines are indented with
        bar(    #   a single tab
          baz)  # but this line is one tab plus two spaces

One test was moved from E10.py to W19.py, since the test correctly no longer produces E101.  Two tests in W19.py have had E101 removed.  The first was using spaces after tabs in a permitted way, for alignment.  The second had mixed tabs and spaces in a multi-line string, and I saw no reason that should be forbidden (what you do in strings is your business).  Finally, one test was added to each of E10.py and W19.py to catch some tricky cases in my own code.

I'm happy to make further explanations, add tests or comments, etc. as required.