### PR TITLE
Require two blank lines after toplevel def/class; issue #400

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1306,6 +1306,8 @@ def filename_match(filename, patterns, default=True):
 
 def _is_eol_token(token):
     return token[0] in NEWLINE or token[4][token[3][1]:].lstrip() == '\\\n'
+
+
 if COMMENT_WITH_NL:
     def _is_eol_token(token, _eol_token=_is_eol_token):
         return _eol_token(token) or (token[0] == tokenize.COMMENT and
@@ -1345,6 +1347,8 @@ def init_checks_registry():
     mod = inspect.getmodule(register_check)
     for (name, function) in inspect.getmembers(mod, inspect.isfunction):
         register_check(function)
+
+
 init_checks_registry()
 
 
@@ -2123,6 +2127,7 @@ def _main():
         if options.count:
             sys.stderr.write(str(report.total_errors) + '\n')
         sys.exit(1)
+
 
 if __name__ == '__main__':
     _main()

--- a/testsuite/E12not.py
+++ b/testsuite/E12not.py
@@ -139,6 +139,7 @@ def long_function_name(
         var_four):
     print(var_one)
 
+
 if ((row < 0 or self.moduleCount <= row or
      col < 0 or self.moduleCount <= col)):
     raise Exception("%s,%s - %s" % (row, col, self.moduleCount))
@@ -400,6 +401,7 @@ def unicode2html(s):
                             .replace('"', '&#34;')
                             .replace('\n', '<br>\n'))
 
+
 #
 parser.add_option('--count', action='store_true',
                   help="print total number of errors and warnings "
@@ -615,6 +617,7 @@ def other_example():
         (key, val if val is not None else token.undefined)
         for key, val in node.items()
     ))]
+
 
 foo([
     'bug'

--- a/testsuite/E22.py
+++ b/testsuite/E22.py
@@ -150,6 +150,7 @@ if alpha[:-i]:
 def squares(n):
     return (i**2 for i in range(n))
 
+
 ENG_PREFIXES = {
     -6: "\u03bc",  # Greek letter mu
     -3: "m",

--- a/testsuite/E30.py
+++ b/testsuite/E30.py
@@ -88,3 +88,32 @@ def function():
 It gives error E303: too many blank lines (3)
 """
 #:
+
+#: E305:7:1
+def a():
+    print
+
+    # comment
+
+    # another comment
+a()
+#: E305:8:1
+def a():
+    print
+
+    # comment
+
+    # another comment
+
+try:
+    a()
+except:
+    pass
+#: E305:5:1
+def a():
+    print
+
+# Two spaces before comments, too.
+if a():
+    a()
+#:

--- a/testsuite/support.py
+++ b/testsuite/support.py
@@ -196,5 +196,6 @@ def run_tests(style):
         init_tests(style)
     return style.check_files()
 
+
 # nose should not collect these functions
 init_tests.__test__ = run_tests.__test__ = False

--- a/testsuite/test_all.py
+++ b/testsuite/test_all.py
@@ -59,5 +59,6 @@ def suite():
 def _main():
     return unittest.TextTestRunner(verbosity=2).run(suite())
 
+
 if __name__ == '__main__':
     sys.exit(not _main())


### PR DESCRIPTION
Here's my attempt to fix issue #400. Not sure what the backwards compatibility policy on this'll be, so I left it as enabled by default.