### PR TITLE
Allow --select and --ignore to be combined

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1811,7 +1811,7 @@ class StyleGuide(object):
             options.ignore = tuple(DEFAULT_IGNORE.split(','))
         else:
             # Ignore all checks which are not explicitly selected
-            options.ignore = ('',) if options.select else tuple(options.ignore)
+            options.ignore = tuple(options.ignore)
         options.benchmark_keys = BENCHMARK_KEYS[:]
         options.ignore_code = self.ignore_code
         options.physical_checks = self.get_checks('physical_line')
@@ -1897,8 +1897,13 @@ class StyleGuide(object):
         if len(code) < 4 and any(s.startswith(code)
                                  for s in self.options.select):
             return False
-        return (code.startswith(self.options.ignore) and
-                not code.startswith(self.options.select))
+
+        if self.options.select:
+            selected = code.startswith(self.options.select)
+            ignored = code.startswith(self.options.ignore)
+            return ignored or not selected
+
+        return code.startswith(self.options.ignore)
 
     def get_checks(self, argument_name):
         """Get all the checks for this category.

--- a/testsuite/test_all.py
+++ b/testsuite/test_all.py
@@ -17,7 +17,7 @@ class Pep8TestCase(unittest.TestCase):
     def setUp(self):
         self._style = pep8.StyleGuide(
             paths=[os.path.join(ROOT_DIR, 'testsuite')],
-            select='E,W', quiet=True)
+            select='E,W', ignore='', quiet=True)
 
     def test_doctest(self):
         import doctest

--- a/testsuite/test_api.py
+++ b/testsuite/test_api.py
@@ -194,19 +194,19 @@ class APITestCase(unittest.TestCase):
 
         options = parse_argv('--select E,W').options
         self.assertEqual(options.select, ('E', 'W'))
-        self.assertEqual(options.ignore, ('',))
+        self.assertEqual(options.ignore, ())
 
         options = parse_argv('--select E --ignore E24').options
         self.assertEqual(options.select, ('E',))
-        self.assertEqual(options.ignore, ('',))
+        self.assertEqual(options.ignore, ('E24',))
 
         options = parse_argv('--ignore E --select E24').options
         self.assertEqual(options.select, ('E24',))
-        self.assertEqual(options.ignore, ('',))
+        self.assertEqual(options.ignore, ('E',))
 
         options = parse_argv('--ignore W --select E24').options
         self.assertEqual(options.select, ('E24',))
-        self.assertEqual(options.ignore, ('',))
+        self.assertEqual(options.ignore, ('W',))
 
         pep8style = pep8.StyleGuide(paths=[E11])
         self.assertFalse(pep8style.ignore_code('E112'))
@@ -216,7 +216,6 @@ class APITestCase(unittest.TestCase):
         pep8style = pep8.StyleGuide(select='E', paths=[E11])
         self.assertFalse(pep8style.ignore_code('E112'))
         self.assertTrue(pep8style.ignore_code('W191'))
-        self.assertFalse(pep8style.ignore_code('E241'))
 
         pep8style = pep8.StyleGuide(select='W', paths=[E11])
         self.assertTrue(pep8style.ignore_code('E112'))
@@ -225,7 +224,7 @@ class APITestCase(unittest.TestCase):
 
         pep8style = pep8.StyleGuide(select=('F401',), paths=[E11])
         self.assertEqual(pep8style.options.select, ('F401',))
-        self.assertEqual(pep8style.options.ignore, ('',))
+        self.assertEqual(pep8style.options.ignore, ('E226', 'E24',))
         self.assertFalse(pep8style.ignore_code('F'))
         self.assertFalse(pep8style.ignore_code('F401'))
         self.assertTrue(pep8style.ignore_code('F402'))


### PR DESCRIPTION
Here we update the logic in the StyleGuide to allow users to specify both
--select and --ignore to combine the power of both flags. Take for
example:

$ pep8 --select=E1 --ignore=E112 testsuite/E11.py

The example shows that we are now allowed to filter out E112 while
selecting the other E1xx checks.

A (potentially unfortunate) consequence of this change is that if a user
specifies --select without --ignore and has codes ignored in their
config file, then we will merge that into the options and continue to
ignore those codes.

Closes #390

---

The tests are going to fail, but I wanted to throw this up for @glyph and others to test.
