### PR TITLE
Attach the original source to the compiled tree

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -1510,7 +1510,9 @@ class Checker(object):
     def check_ast(self):
         """Build the file's AST and run all AST checks."""
         try:
-            tree = compile(''.join(self.lines), '', 'exec', PyCF_ONLY_AST)
+            source = ''.join(self.lines)
+            tree = compile(source, '', 'exec', PyCF_ONLY_AST)
+            tree.source = source
         except (ValueError, SyntaxError, TypeError):
             return self.report_invalid_syntax()
         for name, cls, __ in self._ast_checks:


### PR DESCRIPTION
Issue:

When flake8 is being piped a file, stdin is consumed by pep8. A checker is
unable to evaluate the original source.

`seek(0)` is not possible since it is illegal in a pipe.  Constructing the
source from the tree gives unreliable line numbers.

The goal here is to build an IDE plugin, working specially with Atom.
