### PR TITLE
Do not report E302 occurring on first logical line

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -254,7 +254,7 @@ def blank_lines(logical_line, blank_lines, indent_level, line_number,
     E303: def a():\n\n\n\n    pass
     E304: @decorator\n\ndef a():\n    pass
     """
-    if line_number < 3 and not previous_logical:
+    if not previous_logical and blank_before <= 2:
         return  # Don't expect blank lines before the first line
     if previous_logical.startswith('@'):
         if blank_lines:

--- a/testsuite/E30.py
+++ b/testsuite/E30.py
@@ -16,11 +16,6 @@ class X:
 #:
 
 
-#: E302:3:1
-#!python
-# -*- coding: utf-8 -*-
-def a():
-    pass
 #: E302:2:1
 """Main module."""
 def _main():
@@ -87,4 +82,19 @@ def function():
 """This class docstring comes on line 5.
 It gives error E303: too many blank lines (3)
 """
+#: E303:6:1
+#!python
+# -*- coding: utf-8 -*-
+
+
+
+def a():
+    pass
+#: E303:5:1
+#!python
+
+
+
+if True:
+    pass
 #:

--- a/testsuite/E30not.py
+++ b/testsuite/E30not.py
@@ -14,6 +14,38 @@ class X:
 def foo():
     pass
 #: Okay
+#!python
+# -*- coding: utf-8 -*-
+def a():
+    pass
+#: Okay
+#!python
+# -*- coding: utf-8 -*-
+# A real comment
+def a():
+    pass
+#: Okay
+#!python
+# -*- coding: utf-8 -*-
+
+# A real comment
+def a():
+    pass
+#: Okay
+#!python
+# -*- coding: utf-8 -*-
+
+# A real comment
+
+def a():
+    pass
+#: Okay
+#!python
+
+
+if True:
+    pass
+#: Okay
 class X:
 
     def a():


### PR DESCRIPTION
67b8be8 introduced an exception for E302 if the
first top level function or class was preceded
with only one comment line.

PEP 263 explicitly allows for two lines of comments
at the top of a module, in order to support a
hash-bang and an encoding declaration.

When the first top level function or class appears on the
first logical line, i.e. preceded only by comments, E302
should not be reported as the pep8 utility typically
ignores comments appearing anywhere in the code being checked.

Fixes #412
