### PR TITLE
Allow users to disable extraneous_whitespace with noqa

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -270,7 +270,7 @@ def blank_lines(logical_line, blank_lines, indent_level, line_number,
             yield 0, "E302 expected 2 blank lines, found %d" % blank_before
 
 
-def extraneous_whitespace(logical_line):
+def extraneous_whitespace(logical_line, noqa):
     r"""Avoid extraneous whitespace.
 
     Avoid extraneous whitespace in these situations:
@@ -289,6 +289,8 @@ def extraneous_whitespace(logical_line):
     E203: if x == 4: print x, y ; x, y = y, x
     E203: if x == 4 : print x, y; x, y = y, x
     """
+    if noqa:
+        return
     line = logical_line
     for match in EXTRANEOUS_WHITESPACE_REGEX.finditer(line):
         text = match.group()


### PR DESCRIPTION
This allows for better formatting of numpy arrays and dataframes.

I was writing tests for a project that does a lot of numpy and pandas related operations. Many of the tests are blackbox tests that feed some numpy array in as input and assert that it matches the hand calculated output. When writing out large numpy array literals I often need to add extra spacing to make things line up, this is also closer to how numpy reprs arrays by default.

The exact case I just came up with looks like:

``` python
            expected = pd.DataFrame(
                columns=[
                    'other', 'value',
                ],
                data=[
                    [     1,      0],  # 2014-01-01 Equity(65 [A])
                    [np.nan,      1],             # Equity(66 [B])
                    [     2, np.nan],             # Equity(67 [C])
                    [     1,      1],  # 2014-01-02 Equity(65 [A])
                    [     2,      1],             # Equity(66 [B])
                    [     3,      3],             # Equity(67 [C])
                    [     2,      1],  # 2014-01-03 Equity(65 [A])
                    [     3,      3],             # Equity(66 [B])
                    [     3,      3],             # Equity(67 [C])
                ],
                index=pd.MultiIndex.from_product(
                    (self.dates, finder.retrieve_all(self.sids)),
                ),
            )  # noqa
```

I think that this makes it much easier to visualize what this dataframe will look like by keeping all of the columns in line. Because I have a `NaN` in the left column, I need to indent the integers which causes the warning. For comparision, these are the reprs of `ndarray` and `dataframe`:

``` python
In [1]: np.array([[np.nan, 1], [2, 3]])
Out[1]: 
array([[ nan,   1.],
       [  2.,   3.]])

In [2]: pd.DataFrame(np.array([[np.nan, 1], [2, 3]]), columns=['a', 'b'])
Out[2]: 
    a  b
0 NaN  1
1   2  3
```

I would also be satisfied by requiring a `noqa` on each line that does this; however, this type of check seems to require a logical line. I tried porting it to use physical lines but I am not familiar enough with this code to make that happen without triggering false alerts everywhere.
