### PR TITLE
Allow spaces around = in async definitions

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -776,6 +776,7 @@ def whitespace_around_named_parameter_equals(logical_line, tokens):
     Okay: boolean(a <= b)
     Okay: boolean(a >= b)
     Okay: def foo(arg: int = 42):
+    Okay: async def foo(arg: int = 42):
 
     E251: def complex(real, imag = 0.0):
     E251: return magic(r = real, i = imag)
@@ -784,7 +785,7 @@ def whitespace_around_named_parameter_equals(logical_line, tokens):
     no_space = False
     prev_end = None
     annotated_func_arg = False
-    in_def = logical_line.startswith('def')
+    in_def = logical_line.startswith(('def', 'async def'))
     message = "E251 unexpected spaces around keyword / parameter equals"
     for token_type, text, start, end, line in tokens:
         if token_type == tokenize.NL:

--- a/testsuite/E25.py
+++ b/testsuite/E25.py
@@ -35,3 +35,6 @@ d[type(None)] = _deepcopy_atomic
 def munge(input: AnyStr, sep: AnyStr = None, limit=1000,
           extra: Union[str, dict] = None) -> AnyStr:
     pass
+#: Okay
+async def add(a: int = 0, b: int = 0) -> int:
+    return a + b


### PR DESCRIPTION
In pull request gh-361, we allowed spaces around = for default
arguments with annotations. Python 3.5 added the async keyword for
a function definition and the allowance we made in gh-361 was failing.

This allows a function definition to start with either 'def' or
'async def' now and accommodates both cases.

Closes gh-507