### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -406,7 +406,7 @@ Bug fixes:
   (Issue #93 and #141)
 
 * Add the Sphinx-based documentation, and publish it
-  on http://pep8.readthedocs.org/. (Issue #105)
+  on https://pep8.readthedocs.io/. (Issue #105)
 
 
 1.3.4 (2012-12-18)

--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,4 +1,4 @@
 Contributing to ``pep8``
 ========================
 
-Please see the `developer notes <https://pep8.readthedocs.org/en/latest/developer.html>`_
+Please see the `developer notes <https://pep8.readthedocs.io/en/latest/developer.html>`_

--- a/README.rst
+++ b/README.rst
@@ -91,6 +91,6 @@ Links
    :target: https://pypi.python.org/pypi/pycodestyle
    :alt: Wheel Status
 
-* `Read the documentation <http://pycodestyle.readthedocs.org/>`_
+* `Read the documentation <https://pycodestyle.readthedocs.io/>`_
 
 * `Fork me on GitHub <http://github.com/PyCQA/pycodestyle>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ Contents:
    API <api>
    developer
 
-* Online documentation: http://pep8.readthedocs.org/
+* Online documentation: https://pep8.readthedocs.io/
 * Source code and issue tracker: https://github.com/pycqa/pycodestyle
 
 

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -429,7 +429,7 @@ Note: most errors can be listed with such one-liner::
 Related tools
 -------------
 
-The `flake8 checker <https://flake8.readthedocs.org>`_ is a wrapper around
+The `flake8 checker <https://flake8.readthedocs.io>`_ is a wrapper around
 ``pep8`` and similar tools. It supports plugins.
 
 Other tools which use ``pep8`` are referenced in the Wiki: `list of related

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     keywords='pycodestyle, pep8, PEP 8, PEP-8, PEP8',
     author='Johann C. Rocholl',
     author_email='johann@rocholl.net',
-    url='http://pep8.readthedocs.org/',
+    url='https://pep8.readthedocs.io/',
     license='Expat license',
     py_modules=['pycodestyle'],
     namespace_packages=[],


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.