### PR TITLE
Allow dunder variables above imports

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -119,6 +119,7 @@ KEYWORD_REGEX = re.compile(r'(\s*)\b(?:%s)\b(\s*)' % r'|'.join(KEYWORDS))
 OPERATOR_REGEX = re.compile(r'(?:[^,\s])(\s*)(?:[-+*/|!<=>%&^]+)(\s*)')
 LAMBDA_REGEX = re.compile(r'\blambda\b')
 HUNK_REGEX = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@.*$')
+DUNDER_REGEX = re.compile(r'^__([^\s]+)__ = ')
 
 # Work around Python < 2.6 behaviour, which does not generate NL after
 # a comment which is on a line by itself.
@@ -913,6 +914,8 @@ def module_imports_on_top_of_file(
     if line.startswith('import ') or line.startswith('from '):
         if checker_state.get('seen_non_imports', False):
             yield 0, "E402 module level import not at top of file"
+    elif re.match(DUNDER_REGEX, line):
+        return
     elif any(line.startswith(kw) for kw in allowed_try_keywords):
         # Allow try, except, else, finally keywords intermixed with imports in
         # order to support conditional importing

--- a/testsuite/E40.py
+++ b/testsuite/E40.py
@@ -11,8 +11,16 @@ from foo.bar.yourclass import YourClass
 
 import myclass
 import foo.bar.yourclass
-#: E402
+#: Okay
 __all__ = ['abc']
+
+import foo
+#: Okay
+__version__ = "42"
+
+import foo
+#: Okay
+__author__ = "Simon Gomizelj"
 
 import foo
 #: Okay


### PR DESCRIPTION
Not sure if this is desirable over maintaining a white listing special variables, but otherwise does the trick.

Closes #394
