### PR TITLE
Change all references to the pep8 project to say pycodestyle

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -167,13 +167,14 @@ Quick help is available on the command line::
       --benchmark        measure processing speed
 
     Configuration:
-      The project options are read from the [pep8] section of the tox.ini
-      file or the setup.cfg file located in any parent folder of the path(s)
-      being processed.  Allowed options are: exclude, filename, select,
+      The project options are read from the [pycodestyle] section of the
+      tox.ini file or the setup.cfg file located in any parent folder of the
+      path(s) being processed.  Allowed options are: exclude, filename, select,
       ignore, max-line-length, hang-closing, count, format, quiet, show-pep8,
       show-source, statistics, verbose.
 
-      --config=path      user config file location (default: ~/.config/pep8)
+      --config=path      user config file location
+      (default: ~/.config/pycodestyle)
 
 
 Configuration
@@ -184,23 +185,23 @@ The behaviour may be configured at two levels, the user and project levels.
 At the user level, settings are read from the following locations:
 
 If on Windows:
-    ``~\.pep8``
+    ``~\.pycodestyle``
 
 Otherwise, if the :envvar:`XDG_CONFIG_HOME` environment variable is defined:
-    ``XDG_CONFIG_HOME/pep8``
+    ``XDG_CONFIG_HOME/pycodestyle``
 
 Else if :envvar:`XDG_CONFIG_HOME` is not defined:
-    ``~/.config/pep8``
+    ``~/.config/pycodestyle``
 
 Example::
 
-  [pep8]
+  [pycodestyle]
   ignore = E226,E302,E41
   max-line-length = 160
 
 At the project level, a ``setup.cfg`` file or a ``tox.ini`` file is read if
-present. If none of these files have a ``[pep8]`` section, no project specific
-configuration is loaded.
+present. If none of these files have a ``[pycodestyle]`` section, no project
+specific configuration is loaded.
 
 
 Error codes

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -70,11 +70,11 @@ DEFAULT_EXCLUDE = '.svn,CVS,.bzr,.hg,.git,__pycache__,.tox'
 DEFAULT_IGNORE = 'E121,E123,E126,E226,E24,E704,W503'
 try:
     if sys.platform == 'win32':
-        USER_CONFIG = os.path.expanduser(r'~\.pep8')
+        USER_CONFIG = os.path.expanduser(r'~\.pycodestyle')
     else:
         USER_CONFIG = os.path.join(
             os.getenv('XDG_CONFIG_HOME') or os.path.expanduser('~/.config'),
-            'pep8'
+            'pycodestyle'
         )
 except ImportError:
     USER_CONFIG = None
@@ -1965,7 +1965,7 @@ class StyleGuide(object):
         return sorted(checks)
 
 
-def get_parser(prog='pep8', version=__version__):
+def get_parser(prog='pycodestyle', version=__version__):
     """Create the parser for the program."""
     parser = OptionParser(prog=prog, version=version,
                           usage="%prog [options] input ...")
@@ -2033,7 +2033,7 @@ def read_config(options, args, arglist, parser):
     If a config file is specified on the command line with the "--config"
     option, then only it is used for configuration.
 
-    Otherwise, the user configuration (~/.config/pep8) and any local
+    Otherwise, the user configuration (~/.config/pycodestyle) and any local
     configurations in the current directory or above will be merged together
     (in that order) using the read method of ConfigParser.
     """
@@ -2101,7 +2101,7 @@ def process_options(arglist=None, parse_argv=False, config_file=None,
     """Process options passed either via arglist or via command line args.
 
     Passing in the ``config_file`` parameter allows other tools, such as flake8
-    to specify their own options to be processed in pep8.
+    to specify their own options to be processed in pycodestyle.
     """
     if not parser:
         parser = get_parser()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [wheel]
 universal = 1
 
-[pep8]
+[pycodestyle]
 select =
 ignore = E226,E24
 max_line_length = 79

--- a/testsuite/test_api.py
+++ b/testsuite/test_api.py
@@ -172,7 +172,7 @@ class APITestCase(unittest.TestCase):
     def test_styleguide_ignore_code(self):
         def parse_argv(argstring):
             _saved_argv = sys.argv
-            sys.argv = shlex.split('pep8 %s /dev/null' % argstring)
+            sys.argv = shlex.split('pycodestyle %s /dev/null' % argstring)
             try:
                 return pycodestyle.StyleGuide(parse_argv=True)
             finally:

--- a/testsuite/test_parser.py
+++ b/testsuite/test_parser.py
@@ -19,7 +19,7 @@ class ParserTestCase(unittest.TestCase):
 
     def test_vanilla_ignore_parsing(self):
         contents = b"""
-[pep8]
+[pycodestyle]
 ignore = E226,E24
         """
         options, args = _process_file(contents)
@@ -28,7 +28,7 @@ ignore = E226,E24
 
     def test_multiline_ignore_parsing(self):
         contents = b"""
-[pep8]
+[pycodestyle]
 ignore =
     E226,
     E24
@@ -40,7 +40,7 @@ ignore =
 
     def test_trailing_comma_ignore_parsing(self):
         contents = b"""
-[pep8]
+[pycodestyle]
 ignore = E226,
         """
 
@@ -50,7 +50,7 @@ ignore = E226,
 
     def test_multiline_trailing_comma_ignore_parsing(self):
         contents = b"""
-[pep8]
+[pycodestyle]
 ignore =
     E226,
     E24,


### PR DESCRIPTION
This fixes issue #518, pep8 still referenced in the cli help command
As a side effect,  in setup.cfg now becomes
Also, changed the path for the config file from ~/.config/pep8 to ~/.config/pycodestyle
These feel like changes that should have come with the jump to version 2.0.0, as they are breaking,
but support for  as a name can still be added if it's desired enough