### PR TITLE
Update Python version list in docs

### DIFF
--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -14,7 +14,7 @@ conditions of the :ref:`Expat license <license>`.  Fork away!
 * `Source code <https://github.com/pycqa/pycodestyle>`_ and
   `issue tracker <https://github.com/pycqa/pycodestyle/issues>`_ on GitHub.
 * `Continuous tests <http://travis-ci.org/pycqa/pycodestyle>`_ against Python
-  2.6 through 3.4 and PyPy, on `Travis-CI platform
+  2.6 through 3.5 and PyPy, on `Travis-CI platform
   <http://about.travis-ci.org/>`_.
 
 .. _available on GitHub: https://github.com/pycqa/pycodestyle


### PR DESCRIPTION
Just a tiny doc update to list the correct Python versions that are currently tested in Travis.