### PR TITLE
Switch Travis to use tox

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,28 @@
 language: python
 sudo: false
-python:
-  - 2.6
-  - 2.7
-  - 3.2
-  - 3.3
-  - 3.4
-  - 3.5
-  - nightly
-  - pypy
-  - pypy3
 install:
-  - pip install -e .
-  - pip list
-script:
-  - python pycodestyle.py --testsuite testsuite
-  - python pycodestyle.py --statistics pycodestyle.py
-  - python pycodestyle.py --doctest
-  - python setup.py test
+  - pip install tox
+script: tox
+matrix:
+  include:
+    - python: 2.6
+      env: TOXENV=py26
+    - python: 2.7
+      env: TOXENV=py27
+    - python: 3.3
+      env: TOXENV=py33
+    - python: 3.4
+      env: TOXENV=py34
+    - python: 3.5
+      env: TOXENV=py35
+    - python: 3.6
+      env: TOXENV=py36
+    - python: nightly
+      env: TOXENV=py37
+    - python: pypy
+      env: TOXENV=pypy
+    - python: 3.5
+      env: TOXENV=flake8
 
 notifications:
   email:

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, pypy, pypy3, jython
+envlist = py26, py27, py32, py33, py34, py35, py36, pypy, pypy3, jython
 skip_missing_interpreters=True
 
 [testenv]
@@ -14,3 +14,9 @@ commands =
 	{envpython} pycodestyle.py --statistics pycodestyle.py
 	{envpython} pycodestyle.py --doctest
 	{envpython} setup.py test
+
+[testenv:flake8]
+deps =
+    flake8
+commands =
+    flake8 pycodestyle.py


### PR DESCRIPTION
This reduces confusion about how travis runs tests versus a local
developer.

**Note** this also adds a Flake8 test env and runs it at the gate to catch other instances of https://github.com/PyCQA/pycodestyle/pull/540
