### PR TITLE
Print 0 when using the --count and no errors

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,7 @@ Changelog
 Changes:
 
 * Added check E74x for using variables named 'l', 'O', or 'I'; #341
+* Using the ``--count`` flag now always prints a value (defaults to zero); #425
 
 
 2.0.0 (2016-05-31)

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -2058,7 +2058,7 @@ def get_parser(prog='pycodestyle', version=__version__):
     parser.add_option('--count', action='store_true',
                       help="print total number of errors and warnings "
                            "to standard error and set exit code to 1 if "
-                           "total is not null")
+                           "total is not zero")
     parser.add_option('--max-line-length', type='int', metavar='n',
                       default=MAX_LINE_LENGTH,
                       help="set maximum allowed line length "
@@ -2246,9 +2246,10 @@ def _main():
     if options.testsuite and not options.quiet:
         report.print_results()
 
+    if options.count:
+        sys.stderr.write(str(report.total_errors) + '\n')
+
     if report.total_errors:
-        if options.count:
-            sys.stderr.write(str(report.total_errors) + '\n')
         sys.exit(1)
 
 


### PR DESCRIPTION
Rebase and merge conflicts resolved. Replaces #425

See comment at: https://github.com/PyCQA/pycodestyle/pull/425#issuecomment-224484004 for discussion about whether to merge this in 2.1 or a future 3.0 release.