### PR TITLE
fix: Cast `verbose` to int in continued_indentation() (fixes #567)

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -443,6 +443,9 @@ def continued_indentation(logical_line, tokens, indent_level, hang_closing,
     if noqa or nrows == 1:
         return
 
+    # Make sure verbose is recieved as an integer
+    verbose = int(verbose)
+
     # indent_next tells us whether the next block is indented; assuming
     # that it is indented by 4 spaces, then we should not allow 4-space
     # indents on the final continuation line; in turn, some other


### PR DESCRIPTION
Added a simple `verbose = int(verbose)` to the top of the function. Afterwards I ran `tox` and all the tests still passed. 

I haven't written a test to make sure this case is covered, partly because I'm not sure how the internals of `pycodestyle` are structured, and also because it seems to be a problem with a fairly trivial solution.