### PR TITLE
Update CHANGES.txt for 2.1.0 release.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,14 +4,33 @@ Changelog
 2.1.0 (unreleased)
 ------------------
 
+Announcements:
+
+* Change all references to the pep8 project to say pycodestyle; #530
+
 Changes:
 
-* Added check E74x for using variables named 'l', 'O', or 'I'; #341
-* Improved performance of `compound_statements` check; #314 / #522
-* Fixed remaining references to `pep8`; #518 / #530
-* Added `noqa` support for `maximum_line_length` check; #538
-* Added check E305 for two blank lines after toplevel methods and classes; #400
+* Add Gitter badge; #557
+* Report E302 for blank lines before an "async def"; #556
+* Updated tox to do same tests as Travis CI (`setup.py test`).
+* Updated to use sheilds.io badges.
+* Updated text about running tests with tox; #552
+* Update maximum_line_length to use Checker.noqa; 538
+* Updated Travis CI doc link.
+* Updated docs related to tested Python versions.
+* Added skip missing interpreters flag to tox config.
+* Add test-requirements.txt with basic test packages.
+* Report E742 and E743 for badly named functions and classes.
+* Also report E741 on 'global' and 'nonlocal' statements.
+* Report E741 for prohibited single-letter variables.
+* Added venv/ (virtualenv) to list of git ignored filename patterns.
 
+Bugs:
+
+* Stop checking for string option type; #561
+* Require two blank lines after toplevel def, class; #536
+* Badly named single-letter variable names are not detected; #341
+* Fixing compound_statement not to be quadratic in # of :s; #314
 
 2.0.0 (2016-05-31)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,7 +11,7 @@ Announcements:
 Changes:
 
 * Report E302 for blank lines before an "async def"; #556
-* Update our list of tested and supported Python versions which are 2.6 through 3.5 as well as the nightly Python build and PyPy.
+* Update our list of tested and supported Python versions which are 2.6, 2.7, 3.2, 3.3, 3.4 and 3.5 as well as the nightly Python build and PyPy.
 * Report E742 and E743 for functions and classes badly named 'l', 'O', or 'I'.
 * Report E741 on 'global' and 'nonlocal' statements, as well as prohibited single-letter variables.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -10,27 +10,16 @@ Announcements:
 
 Changes:
 
-* Add Gitter badge; #557
 * Report E302 for blank lines before an "async def"; #556
-* Updated tox to do same tests as Travis CI (`setup.py test`).
-* Updated to use sheilds.io badges.
-* Updated text about running tests with tox; #552
-* Update maximum_line_length to use Checker.noqa; 538
-* Updated Travis CI doc link.
-* Updated docs related to tested Python versions.
-* Added skip missing interpreters flag to tox config.
-* Add test-requirements.txt with basic test packages.
-* Report E742 and E743 for badly named functions and classes.
-* Also report E741 on 'global' and 'nonlocal' statements.
-* Report E741 for prohibited single-letter variables.
-* Added venv/ (virtualenv) to list of git ignored filename patterns.
+* Update our list of tested and supported Python versions which are 2.6 through 3.5 as well as the nightly Python build and PyPy.
+* Report E742 and E743 for functions and classes badly named 'l', 'O', or 'I'.
+* Report E741 on 'global' and 'nonlocal' statements, as well as prohibited single-letter variables.
 
 Bugs:
 
-* Stop checking for string option type; #561
+* Fix opt_type AssertionError when using Flake8 2.6.2 and pycodestyle 2.0.0; #561
 * Require two blank lines after toplevel def, class; #536
-* Badly named single-letter variable names are not detected; #341
-* Fixing compound_statement not to be quadratic in # of :s; #314
+* Remove accidentally quadratic computation based on the number of colons. This will make pycodestyle faster in some cases; #314
 
 2.0.0 (2016-05-31)
 ------------------


### PR DESCRIPTION
Per #573, 

I'm not exactly sure what exactly is important to you to have in the changelog.

I ran `git log 2.0.0..HEAD --oneline` on `master` and then trimmed up the following output, based on what sounded important/useful.

```
1391c7e Update CHANGES.txt for 2.1.0 release.
1e71012 Merge pull request #562 from sigmavirus24/bug/561
d4b8f49 Stop checking for string option type
0babee5 Merge pull request #557 from gitter-badger/gitter-badge
df8a6c0 Add Gitter badge
001a0ce Merge pull request #556 from markpeek/markpeek-async-def
72acd6f Report E302 for blank lines before an "async def"
4438622 Updated tox to do same tests as Travis CI
5c4c081 Removed test code unrelated to utf-8 checks
08f4891 Merge branch 'gh-536'
a0d5d5d Added test case based on @gvanrossum comment
2a5e575 Updated checker variable based on conversation in #536
10f4e51 Added extra Okay example to test against
f55b1c5 Fixed placement of changelog entry
6b75c4d Fix issue #400: Require two blank lines after toplevel def, class
dc08dad Updated changelog with 2.1 milestone changes
5a6ffd5 Updated rename note in README
e01ca2f Updated to use sheilds.io badges
15b1b42 Updated text about running tests with tox; Closes #552
f8af83d Merge pull request #539 from sigmavirus24/max-line-length-noqa
1fcd279 Merge pull request #540 from sigmavirus24/remove-warnings
95ed849 Remove unused imports and assignments
7fa71af Update maximum_line_length to use Checker.noqa
6cb59d6 Updated changelog to specify changes in 2.1.0
4ccdc55 Merge pull request #525 from mtmiller/issue341
60859d6 Updated version number of next release to 2.1.0
e15075a Updated Travis CI doc link
d2171cd Updated docs related to tested Python versions
42c8987 Added passing test case related to #376
ca7e43b Fixed wrapping of text in developer.rst
fc8c799 Added skip missing interpreters flag to tox config
45503fc Updated developer documentation for testing
5be92ad Add test-requirements.txt with basic test packages
7ffd648 Reverted a few spelling changes
adcb3a2 Fix typos
e8d358e Re-ordered package imports alphabetically
64edd89 Bumped version number post release
c122532 Merge pull request #532 from mtmiller/doc-update
77f5543 Merge pull request #530 from iamaspacecow/pycodestyle-name-change
26c64ba Change all references to the pep8 project to say pycodestyle This fixes issue #518, pep8 still referenced in the cli help command As a side effect, `[pep8]` in setup.cfg now becomes `[pycodestyle]` Also, changed the path for the config file from ~/.config/pep8 to ~/.config/pycodestyle These feel like changes that should have come with the jump to version 2.0.0, as they are breaking, but support for  as a name can still be added if it's desired enough
b98ed7b Update Python version list in docs
fdf3e6a Report E742 and E743 for badly named functions and classes
017d3b5 Also report E741 on 'global' and 'nonlocal' statements
4c8152c Add more doctests for E741
b02d768 Merge pull request #522 from arthall/issue-314
26893da Report E741 for prohibited single-letter variables
a99bcec Never use 'l' (lowercase letter el) as a variable name
5949086 Modified patch for issue #314 so tests in E73.py pass
3944d9e Merge pull request #520 from kjcole/master
6fe11c4 - Added venv/ (virtualenv) to list of git ignored filename patterns
5cf3c7a Merge latest master into issue-314
bbefb19 Fixing compound_statement not to be quadratic in # of :s
```

LMKWYT and I'll update accordingly.