### PR TITLE
Update pycodestyle.py

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -290,7 +290,7 @@ def blank_lines(logical_line, blank_lines, indent_level, line_number,
         elif blank_before != 2:
             yield 0, "E302 expected 2 blank lines, found %d" % blank_before
     elif (logical_line and not indent_level and blank_before != 2 and
-          previous_unindented_logical_line.startswith(('def', 'class'))):
+          previous_unindented_logical_line.startswith(('def ', 'class '))):
         yield 0, "E305 expected 2 blank lines after " \
             "class or function definition, found %d" % blank_before
 

--- a/testsuite/E305not.py
+++ b/testsuite/E305not.py
@@ -1,2 +1,0 @@
-classification_errors = None
-defined_properly = True

--- a/testsuite/E305not.py
+++ b/testsuite/E305not.py
@@ -1,0 +1,2 @@
+classification_errors = None
+defined_properly = True

--- a/testsuite/E30not.py
+++ b/testsuite/E30not.py
@@ -151,3 +151,7 @@ class Bar(object):
 
 if __name__ == '__main__':
     foo()
+#: Okay
+classification_errors = None
+#: Okay
+defined_properly = True


### PR DESCRIPTION
Prevent lines like 

```
classification_error = 0 
```

From becoming treated as a class.
