### PR TITLE
Fix: os.walk() should have followlinks set to True.

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1992,7 +1992,7 @@ class StyleGuide(object):
         verbose = self.options.verbose
         filepatterns = self.options.filename
         runner = self.runner
-        for root, dirs, files in os.walk(dirname):
+        for root, dirs, files in os.walk(dirname, followlinks=True):
             if verbose:
                 print('directory ' + root)
             counters['directories'] += 1


### PR DESCRIPTION
Fix: os.walk() should have followlinks set to True in order to also follow symbolic links when evaluating files.