### PR TITLE
 added function doc to blank_lines() for E306

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -264,6 +264,7 @@ def blank_lines(logical_line, blank_lines, indent_level, line_number,
     E303: def a():\n\n\n\n    pass
     E304: @decorator\n\ndef a():\n    pass
     E305: def a():\n    pass\na()
+    E306: def a():\n    def b():\n        pass\n    def c():\n        pass
     """
     if line_number < 3 and not previous_logical:
         return  # Don't expect blank lines before the first line


### PR DESCRIPTION
without it `register_check()` using ERRORCODE_REGEX will not register E306 into error code list. This in effect will make `pycodestyle --select=E306` to not work.