### PR TITLE
Don't report E701 for variable annotations

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -123,6 +123,17 @@ LAMBDA_REGEX = re.compile(r'\blambda\b')
 HUNK_REGEX = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@.*$')
 STARTSWITH_DEF_REGEX = re.compile(r'^(async\s+def|def)')
 STARTSWITH_TOP_LEVEL_REGEX = re.compile(r'^(async\s+def|def|class|@)')
+STARTSWITH_INDENT_STATEMENT_REGEX = re.compile(
+    r'^\s*({0})'.format('|'.join(s.replace(' ', '\s+') for s in (
+        'def', 'async def',
+        'for', 'async for',
+        'if', 'elif', 'else',
+        'try', 'except', 'finally',
+        'with', 'async with',
+        'class',
+        'while',
+    )))
+)
 
 # Work around Python < 2.6 behaviour, which does not generate NL after
 # a comment which is on a line by itself.
@@ -1004,7 +1015,7 @@ def compound_statements(logical_line):
                 break
             if STARTSWITH_DEF_REGEX.match(line):
                 yield 0, "E704 multiple statements on one line (def)"
-            else:
+            elif STARTSWITH_INDENT_STATEMENT_REGEX.match(line):
                 yield found, "E701 multiple statements on one line (colon)"
         prev_found = found
         found = line.find(':', found + 1)

--- a/testsuite/E90.py
+++ b/testsuite/E90.py
@@ -8,7 +8,7 @@ while True:
 	    pass
 	except:
 		print 'Whoops'
-#: E122 E225 E251 E251 E701
+#: E122 E225 E251 E251
 
 # Do not crash if code is invalid
 if msg:

--- a/testsuite/python3.py
+++ b/testsuite/python3.py
@@ -1,6 +1,18 @@
 #!/usr/bin/env python3
+from typing import ClassVar, List
 
 
 # Annotated function (Issue #29)
 def foo(x: int) -> int:
     return x + 1
+
+
+# Annotated variables #575
+CONST: int = 42
+
+
+class Class:
+    cls_var: ClassVar[str]
+
+    def m(self):
+        xs: List[int] = []


### PR DESCRIPTION
This is based on #611 to avoid a conflict.  I can rebase / reorder if requested.

This resolves #575