### PR TITLE
Fix regression in E302 detection

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -122,7 +122,7 @@ OPERATOR_REGEX = re.compile(r'(?:[^,\s])(\s*)(?:[-+*/|!<=>%&^]+)(\s*)')
 LAMBDA_REGEX = re.compile(r'\blambda\b')
 HUNK_REGEX = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@.*$')
 STARTSWITH_DEF_REGEX = re.compile(r'^(async\s+def|def)')
-STARTSWITH_TOP_LEVEL_REGEX = re.compile(r'^(async\s+def|def|class|@)')
+STARTSWITH_TOP_LEVEL_REGEX = re.compile(r'^(async\s+def |def |class |@)')
 STARTSWITH_INDENT_STATEMENT_REGEX = re.compile(
     r'^\s*({0})'.format('|'.join(s.replace(' ', '\s+') for s in (
         'def', 'async def',

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -122,7 +122,7 @@ OPERATOR_REGEX = re.compile(r'(?:[^,\s])(\s*)(?:[-+*/|!<=>%&^]+)(\s*)')
 LAMBDA_REGEX = re.compile(r'\blambda\b')
 HUNK_REGEX = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@.*$')
 STARTSWITH_DEF_REGEX = re.compile(r'^(async\s+def|def)')
-STARTSWITH_TOP_LEVEL_REGEX = re.compile(r'^(async\s+def |def |class |@)')
+STARTSWITH_TOP_LEVEL_REGEX = re.compile(r'^(async\s+def\s+|def\s+|class\s+|@)')
 STARTSWITH_INDENT_STATEMENT_REGEX = re.compile(
     r'^\s*({0})'.format('|'.join(s.replace(' ', '\s+') for s in (
         'def', 'async def',

--- a/testsuite/E30not.py
+++ b/testsuite/E30not.py
@@ -155,3 +155,6 @@ if __name__ == '__main__':
 classification_errors = None
 #: Okay
 defined_properly = True
+#: Okay
+defaults = {}
+defaults.update({})


### PR DESCRIPTION
This was similar to an issue we had with E306 in which we were only
checking that a line started with "def" or "class" which catches global
vars like "defaults" or "classification".

Closes gh-617