### PR TITLE
Add regression test for nested definitions

### DIFF
--- a/testsuite/E30not.py
+++ b/testsuite/E30not.py
@@ -158,3 +158,7 @@ defined_properly = True
 #: Okay
 defaults = {}
 defaults.update({})
+#: Okay
+def foo(x):
+    classification = x
+    definitely = not classification


### PR DESCRIPTION
The bug was already fixed since it also affected E302 but this adds a
test to ensure it doesn't regress for nested definitions either.

Closes gh-619