### PR TITLE
Correctly report E501 when the first line of a docstring is too long

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1199,7 +1199,7 @@ def comparison_type(logical_line, noqa):
 
 
 def bare_except(logical_line, noqa):
-    r"""When catching exceptions, mention specific exceptions whenever possible.
+    r"""When catching exceptions, mention specific exceptions when possible.
 
     Okay: except Exception:
     Okay: except BaseException:
@@ -1727,7 +1727,9 @@ class Checker(object):
                 return
             self.multiline = True
             self.line_number = token[2][0]
-            for line in token[1].split('\n')[:-1]:
+            _, src, (_, offset), _, _ = token
+            src = self.lines[self.line_number - 1][:offset] + src
+            for line in src.split('\n')[:-1]:
                 self.check_physical(line + '\n')
                 self.line_number += 1
             self.multiline = False

--- a/testsuite/E50.py
+++ b/testsuite/E50.py
@@ -82,6 +82,11 @@ that I'm calling:
 #: E501
 """
 longnospaceslongnospaceslongnospaceslongnospaceslongnospaceslongnospaceslongnospaceslongnospaces"""
+#: E501
+# Regression test for #622
+def foo():
+    """Lorem ipsum dolor sit amet, consectetur adipiscing elit. Duis pulvinar vitae
+    """
 #: Okay
 """
 This


### PR DESCRIPTION
Resolves #622