### PR TITLE
Support variable annotation when variable start by a keyword

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -121,10 +121,10 @@ KEYWORD_REGEX = re.compile(r'(\s*)\b(?:%s)\b(\s*)' % r'|'.join(KEYWORDS))
 OPERATOR_REGEX = re.compile(r'(?:[^,\s])(\s*)(?:[-+*/|!<=>%&^]+)(\s*)')
 LAMBDA_REGEX = re.compile(r'\blambda\b')
 HUNK_REGEX = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@.*$')
-STARTSWITH_DEF_REGEX = re.compile(r'^(async\s+def|def)')
+STARTSWITH_DEF_REGEX = re.compile(r'^(async\b+def|def)')
 STARTSWITH_TOP_LEVEL_REGEX = re.compile(r'^(async\s+def\s+|def\s+|class\s+|@)')
 STARTSWITH_INDENT_STATEMENT_REGEX = re.compile(
-    r'^\s*({0})\s'.format('|'.join(s.replace(' ', '\s+') for s in (
+    r'^\s*({0})\b'.format('|'.join(s.replace(' ', '\s+') for s in (
         'def', 'async def',
         'for', 'async for',
         'if', 'elif', 'else',

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -124,7 +124,7 @@ HUNK_REGEX = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@.*$')
 STARTSWITH_DEF_REGEX = re.compile(r'^(async\s+def|def)')
 STARTSWITH_TOP_LEVEL_REGEX = re.compile(r'^(async\s+def\s+|def\s+|class\s+|@)')
 STARTSWITH_INDENT_STATEMENT_REGEX = re.compile(
-    r'^\s*({0})'.format('|'.join(s.replace(' ', '\s+') for s in (
+    r'^\s*({0})\s'.format('|'.join(s.replace(' ', '\s+') for s in (
         'def', 'async def',
         'for', 'async for',
         'if', 'elif', 'else',

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -121,7 +121,7 @@ KEYWORD_REGEX = re.compile(r'(\s*)\b(?:%s)\b(\s*)' % r'|'.join(KEYWORDS))
 OPERATOR_REGEX = re.compile(r'(?:[^,\s])(\s*)(?:[-+*/|!<=>%&^]+)(\s*)')
 LAMBDA_REGEX = re.compile(r'\blambda\b')
 HUNK_REGEX = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@.*$')
-STARTSWITH_DEF_REGEX = re.compile(r'^(async\b+def|def)')
+STARTSWITH_DEF_REGEX = re.compile(r'^(async\s+def|def)\b')
 STARTSWITH_TOP_LEVEL_REGEX = re.compile(r'^(async\s+def\s+|def\s+|class\s+|@)')
 STARTSWITH_INDENT_STATEMENT_REGEX = re.compile(
     r'^\s*({0})\b'.format('|'.join(s.replace(' ', '\s+') for s in (

--- a/testsuite/python3.py
+++ b/testsuite/python3.py
@@ -13,6 +13,16 @@ CONST: int = 42
 
 class Class:
     cls_var: ClassVar[str]
-
+    for_var: ClassVar[str]
+    while_var: ClassVar[str]
+    def_var: ClassVar[str]
+    if_var: ClassVar[str]
+    elif_var: ClassVar[str]
+    else_var: ClassVar[str]
+    try_var: ClassVar[str]
+    except_var: ClassVar[str]
+    finally_var: ClassVar[str]
+    with_var: ClassVar[str]
+        
     def m(self):
         xs: List[int] = []

--- a/testsuite/python3.py
+++ b/testsuite/python3.py
@@ -23,6 +23,16 @@ class Class:
     except_var: ClassVar[str]
     finally_var: ClassVar[str]
     with_var: ClassVar[str]
+    For_var: ClassVar[str]
+    While_var: ClassVar[str]
+    Def_var: ClassVar[str]
+    If_var: ClassVar[str]
+    Elif_var: ClassVar[str]
+    Else_var: ClassVar[str]
+    Try_var: ClassVar[str]
+    Except_var: ClassVar[str]
+    Finally_var: ClassVar[str]
+    With_var: ClassVar[str]
         
     def m(self):
         xs: List[int] = []


### PR DESCRIPTION
Support case when the variable name start by a keyword, eg:
```
class Test:
    formula: str = None # E701
```

This  PR ensure that we do the codestyle check only for line which start by the keyword followed by a space.