### PR TITLE
Fix issue #643: Optimize noqa() with an lru_cache for Python 3.2+.

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -58,6 +58,16 @@ import tokenize
 import warnings
 import bisect
 
+try:
+    from functools import lru_cache
+except ImportError:
+    def lru_cache(maxsize=128):  # noqa as it's a fake implementation.
+        """Does not really need a real a lru_cache, it's just optimization, so
+        let's just do nothing here. Python 3.2+ will just get better
+        performances, time to upgrade?
+        """
+        return lambda function: function
+
 from fnmatch import fnmatch
 from optparse import OptionParser
 
@@ -1410,7 +1420,7 @@ else:
         """Read the value from stdin."""
         return TextIOWrapper(sys.stdin.buffer, errors='ignore').read()
 
-noqa = re.compile(r'# no(?:qa|pep8)\b', re.I).search
+noqa = lru_cache(512)(re.compile(r'# no(?:qa|pep8)\b', re.I).search)
 
 
 def expand_indent(line):


### PR DESCRIPTION
Fixes https://github.com/PyCQA/pycodestyle/issues/643 for Python 3.2+.


Had to catch a "No signature found for builtin <built-in method
search of _sre.SRE_Pattern object at 0x...>" in 3.4:

In python3.4 the search was not detected as a function, now that it's
wrapped in an lru_cache it is, yet it still has no signature (it has
in 3.5+).