### PR TITLE
Support class variables beginning with indent keywords

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -135,11 +135,11 @@ HUNK_REGEX = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@.*$')
 STARTSWITH_DEF_REGEX = re.compile(r'^(async\s+def|def)')
 STARTSWITH_TOP_LEVEL_REGEX = re.compile(r'^(async\s+def\s+|def\s+|class\s+|@)')
 STARTSWITH_INDENT_STATEMENT_REGEX = re.compile(
-    r'^\s*({0})'.format('|'.join(s.replace(' ', r'\s+') for s in (
+    r'^\s*({0})'.format('|'.join((s + ' ').replace(' ', r'\s+') for s in (
         'def', 'async def',
         'for', 'async for',
-        'if', 'elif', 'else',
-        'try', 'except', 'finally',
+        'if', 'elif', 'else:',
+        'try:', 'except', 'finally:',
         'with', 'async with',
         'class',
         'while',

--- a/testsuite/python3.py
+++ b/testsuite/python3.py
@@ -13,6 +13,16 @@ CONST: int = 42
 
 class Class:
     cls_var: ClassVar[str]
+    ifx: bool
+    elifx: str
+    else_y: str
+    for_a: int
+    while_b: int
+    tryx: int
+    except_x: str
+    finallyx: str
+    with_x: int
+    class_x: int
 
     def m(self):
         xs: List[int] = []


### PR DESCRIPTION
If a Python 3 class variable begins with an indent keyword, i.e.,

class Class:
    with_foo: int

pycodestyle will erroneously output the error 'E701 multiple statements
on one line'. This patch tightens the check so that even variables
beginning with indent keywords are allowed.

Resolves #635