### PR TITLE
Allow continuation of verbosity level

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1995,7 +1995,7 @@ class StyleGuide(object):
         # build options from dict
         options_dict = dict(*args, **kwargs)
         arglist = None if parse_argv else options_dict.get('paths', None)
-        verbose = options_dict.get('verbose', False)
+        verbose = options_dict.get('verbose', 0)
         options, self.paths = process_options(
             arglist, parse_argv, config_file, parser, verbose)
         if options_dict:
@@ -2257,7 +2257,7 @@ def read_config(options, args, arglist, parser):
 
 
 def process_options(arglist=None, parse_argv=False, config_file=None,
-                    parser=None, verbose=False):
+                    parser=None, verbose=0):
     """Process options passed either via arglist or via command line args.
 
     Passing in the ``config_file`` parameter allows other tools, such as flake8

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1995,7 +1995,7 @@ class StyleGuide(object):
         # build options from dict
         options_dict = dict(*args, **kwargs)
         arglist = None if parse_argv else options_dict.get('paths', None)
-        verbose = options_dict.get('verbose', 0)
+        verbose = options_dict.get('verbose', None)
         options, self.paths = process_options(
             arglist, parse_argv, config_file, parser, verbose)
         if options_dict:

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -2257,7 +2257,7 @@ def read_config(options, args, arglist, parser):
 
 
 def process_options(arglist=None, parse_argv=False, config_file=None,
-                    parser=None, verbose=0):
+                    parser=None, verbose=None):
     """Process options passed either via arglist or via command line args.
 
     Passing in the ``config_file`` parameter allows other tools, such as flake8
@@ -2281,7 +2281,8 @@ def process_options(arglist=None, parse_argv=False, config_file=None,
     (options, args) = parser.parse_args(arglist)
     options.reporter = None
 
-    if verbose:  # If specified verbose, continue on verbosity
+    # If explicity specified verbosity, override any `-v` CLI flag
+    if verbose is not None:
         options.verbose = verbose
 
     if options.ensure_value('testsuite', False):

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1995,8 +1995,9 @@ class StyleGuide(object):
         # build options from dict
         options_dict = dict(*args, **kwargs)
         arglist = None if parse_argv else options_dict.get('paths', None)
+        verbose = options_dict.get('verbose', False)
         options, self.paths = process_options(
-            arglist, parse_argv, config_file, parser)
+            arglist, parse_argv, config_file, parser, verbose)
         if options_dict:
             options.__dict__.update(options_dict)
             if 'paths' in options_dict:
@@ -2256,7 +2257,7 @@ def read_config(options, args, arglist, parser):
 
 
 def process_options(arglist=None, parse_argv=False, config_file=None,
-                    parser=None):
+                    parser=None, verbose=False):
     """Process options passed either via arglist or via command line args.
 
     Passing in the ``config_file`` parameter allows other tools, such as flake8
@@ -2279,6 +2280,9 @@ def process_options(arglist=None, parse_argv=False, config_file=None,
     # parsed from the command line (sys.argv)
     (options, args) = parser.parse_args(arglist)
     options.reporter = None
+
+    if verbose:  # If specified verbose, continue on verbosity
+        options.verbose = verbose
 
     if options.ensure_value('testsuite', False):
         args.append(options.testsuite)


### PR DESCRIPTION
I've been having to do ```pycodestyle.StyleGuide(verbose=True, paths=['-v'])``` to achieve verbosity to the point where I can see the configuration files included such as: 
```
user configuration: /home/mjsir911/.config/pycodestyle
cli configuration: setup.cfg
```

This simply allows ```pycodestyle.StyleGuide(verbose=True)``` to display these verbosity messages.