### PR TITLE
Be precise about the noqa comment

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1420,7 +1420,7 @@ else:
         """Read the value from stdin."""
         return TextIOWrapper(sys.stdin.buffer, errors='ignore').read()
 
-noqa = lru_cache(512)(re.compile(r'# no(?:qa|pep8)\b', re.I).search)
+noqa = lru_cache(512)(re.compile(r'# no(?:qa|pep8)(?!:)\b', re.I).search)
 
 
 def expand_indent(line):


### PR DESCRIPTION
pydocstyle uses them as well, but they allow customization like `# noqa: D102`. We do not want those comments to enable unconditional noqa in pycodestyle.