### PR TITLE
Warn that pep8 has been renamed to pycodestyle

### DIFF
--- a/pep8.py
+++ b/pep8.py
@@ -54,6 +54,7 @@ import time
 import inspect
 import keyword
 import tokenize
+import warnings
 from optparse import OptionParser
 from fnmatch import fnmatch
 try:
@@ -63,6 +64,14 @@ except ImportError:
     from ConfigParser import RawConfigParser
 
 __version__ = '1.7.0'
+
+
+warnings.warn('pep8 has been renamed to pycodestyle. '
+              'Please uninstall pep8 and install pycodestyle. '
+              'More info: '
+              'https://github.com/PyCQA/pycodestyle/issues/466',
+              UserWarning)
+
 
 DEFAULT_EXCLUDE = '.svn,CVS,.bzr,.hg,.git,__pycache__,.tox'
 DEFAULT_IGNORE = 'E121,E123,E126,E226,E24,E704'

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,14 @@
 from __future__ import with_statement
 from setuptools import setup
 
+import warnings
+
+warnings.warn('pep8 has been renamed to pycodestyle. '
+              'Please uninstall pep8 and install pycodestyle. '
+              'More info: '
+              'https://github.com/PyCQA/pycodestyle/issues/466',
+              UserWarning)
+
 
 def get_version():
     with open('pep8.py') as f:


### PR DESCRIPTION
Note: PR against 1.7.x branch.

It was suggested in https://github.com/PyCQA/pycodestyle/issues/572 to make an updated package of pep8 with a deprecation warning to make it clear that pep8 has been replaced with pycodestyle.

That issues was opening in September 2016, and they hadn't realised the rename had happened (#466, #481) and were still using the old, outdated tool.

It's now October 2017, and I only just noticed this too!

Here's a suggested warning that could go into an updated pep8 1.7.x to let people know of the change. Perhaps the warning could have wording to make it clear that pep8 is also outdated and no longer maintained.