### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 include *.txt
 include *.rst
+include LICENSE
 recursive-include docs *
 recursive-include testsuite *
 recursive-exclude docs *.pyc

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,9 @@
 [bdist_wheel]
 universal = 1
 
+[metadata]
+license_file = LICENSE
+
 [pycodestyle]
 select =
 ignore = E226,E24


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file