### PR TITLE
Fix missed quoting in E722 check

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1280,7 +1280,7 @@ def bare_except(logical_line, noqa):
     regex = re.compile(r"except\s*:")
     match = regex.match(logical_line)
     if match:
-        yield match.start(), "E722 do not use bare except'"
+        yield match.start(), "E722 do not use bare 'except'"
 
 
 @register_check


### PR DESCRIPTION
The warning looks fairly odd:

E722 do not use bare except'

change this to

E722 do not use bare 'except'