### PR TITLE
Remove support for EOL Python 2.6 and 3.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,8 @@ install:
 script: tox
 matrix:
   include:
-    - python: 2.6
-      env: TOXENV=py26
     - python: 2.7
       env: TOXENV=py27
-    - python: 3.3
-      env: TOXENV=py33
     - python: 3.4
       env: TOXENV=py34
     - python: 3.5

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+UNRELEASED
+----------
+
+Changes:
+
+* Remove support for EOL Python 2.6 and 3.3.
+
 2.4.0 (2018-04-10)
 ------------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,7 @@ UNRELEASED
 
 Changes:
 
-* Remove support for EOL Python 2.6 and 3.3.
+* Remove support for EOL Python 2.6 and 3.3. PR #720.
 
 2.4.0 (2018-04-10)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,8 @@
 Changelog
 =========
 
-UNRELEASED
-----------
+UNRELEASED / 3.0.0
+------------------
 
 Changes:
 

--- a/docs/developer.rst
+++ b/docs/developer.rst
@@ -14,7 +14,7 @@ conditions of the :ref:`Expat license <license>`.  Fork away!
 * `Source code <https://github.com/pycqa/pycodestyle>`_ and
   `issue tracker <https://github.com/pycqa/pycodestyle/issues>`_ on GitHub.
 * `Continuous tests <http://travis-ci.org/pycqa/pycodestyle>`_ against Python
-  2.6 through 3.6 as well as the nightly Python build and PyPy, on `Travis CI
+  2.7 and 3.4+ as well as the nightly Python build and PyPy, on `Travis CI
   platform <https://docs.travis-ci.com//>`_.
 
 .. _available on GitHub: https://github.com/pycqa/pycodestyle
@@ -32,7 +32,6 @@ Some high-level aims and directions to bear in mind for contributions:
 * If you want to provide extensibility / plugins,
   please see `flake8 <https://gitlab.com/pycqa/flake8>`_ -
   ``pycodestyle`` doesn't want or need a plugin architecture.
-* Python 2.6 support is still deemed important.
 * ``pycodestyle`` aims to have no external dependencies.
 
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,7 @@ setup(
     namespace_packages=[],
     include_package_data=True,
     zip_safe=False,
+    python_requires='>=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*',
     install_requires=[
         # Broken with Python 3: https://github.com/pypa/pip/issues/650
         # 'setuptools',
@@ -51,10 +52,8 @@ setup(
         'Operating System :: OS Independent',
         'Programming Language :: Python',
         'Programming Language :: Python :: 2',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',

--- a/testsuite/test_api.py
+++ b/testsuite/test_api.py
@@ -28,10 +28,10 @@ class APITestCase(unittest.TestCase):
         self._saved_checks = pycodestyle._checks
         sys.stdout = PseudoFile()
         sys.stderr = PseudoFile()
-        pycodestyle._checks = dict(
-            (k, dict((f, (vals[0][:], vals[1])) for (f, vals) in v.items()))
-            for (k, v) in self._saved_checks.items()
-        )
+        pycodestyle._checks = {
+            k: {f: (vals[0][:], vals[1]) for (f, vals) in v.items()}
+            for k, v in self._saved_checks.items()
+        }
 
     def tearDown(self):
         sys.stdout = self._saved_stdout

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27, py32, py33, py34, py35, py36, pypy, pypy3, jython
+envlist = py27, py34, py35, py36, pypy, pypy3, jython
 skipsdist = True
 skip_missing_interpreters = True
 


### PR DESCRIPTION
Python 2.6 an 3.3 are end of life. They are no longer receiving bug fixes, including for security issues. Python 2.6 went EOL on 2013-10-29 and 3.3 on 2017-09-29. For additional details on support Python versions, see: https://devguide.python.org/#status-of-python-branches
    
Removing support for EOL Pythons will reduce testing and maintenance resources. Removed all workarounds for older Pythons.
    
Updated trove classifiers and documentation to better communicate supported Python versions.
    
Additionally, pass python_requires argument to setuptools. Helps pip decide what version of the library to install. 
    
https://packaging.python.org/tutorials/distributing-packages/#python-requires
    
> If your project only runs on certain Python versions, setting the python_requires argument to the appropriate PEP 440 version specifier string will prevent pip from installing the project on other Python versions.
    
https://setuptools.readthedocs.io/en/latest/setuptools.html#new-and-changed-setup-keywords
    
> python_requires
>
> A string corresponding to a version specifier (as defined in PEP 440) for the Python version, used to specify the Requires-Python defined in PEP 345.
    
Can now use more modern Python syntax including dictionary comprehension as well as more generators.