### PR TITLE
Allow indenting chained method calls inside parentheses

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -619,7 +619,11 @@ def continued_indentation(logical_line, tokens, indent_level, hang_closing,
                 elif indent[depth]:
                     error = "E127", "over-indented for visual indent"
                 elif not close_bracket and hangs[depth]:
-                    error = "E131", "unaligned for hanging indent"
+                    if token_type == tokenize.OP and text == '.':
+                        # Allow indenting chained method calls.
+                        continue
+                    else:
+                        error = "E131", "unaligned for hanging indent"
                 else:
                     hangs[depth] = hang
                     if hang > 4:

--- a/testsuite/E12.py
+++ b/testsuite/E12.py
@@ -373,4 +373,13 @@ print(True)
 
 print(a
 , end=' ')
-#:
+#: Okay
+qs = (
+    User.objects
+        .filter(username='alice')
+        .exclude(username='bob'))
+qs = (
+    User.objects
+        .filter(username='bob')
+        .exclude(username='alice')
+)


### PR DESCRIPTION
For example, a Django queryset can have many chained method calls (filter, exclude, count, etc.) as well as long arguments. To avoid long lines or ending lines with a backslash, it may be wrapped in parentheses.

```py
user_count = (
    User.objects
        .filter(really_long_filter='thing1')
        .exclude(really_long_exclude='thing2')
        .count())
```

Or with a hanging parenthesis:

```py
user_count = (
    User.objects
        .filter(really_long_filter='thing1')
        .exclude(really_long_exclude='thing2')
        .count()
)
```