### PR TITLE
Add variables for blank lines.

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -328,12 +328,18 @@ def blank_lines(logical_line, blank_lines, indent_level, line_number,
     E305: def a():\n    pass\na()
     E306: def a():\n    def b():\n        pass\n    def c():\n        pass
     """
+    top_level_lines = 3
+    method_lines = 2
+
     if line_number < 3 and not previous_logical:
         return  # Don't expect blank lines before the first line
     if previous_logical.startswith('@'):
         if blank_lines:
             yield 0, "E304 blank lines found after function decorator"
-    elif blank_lines > 2 or (indent_level and blank_lines == 2):
+    elif (
+        blank_lines > method_lines + 1 or
+        (indent_level and blank_lines == method_lines + 1)
+            ):
         yield 0, "E303 too many blank lines (%d)" % blank_lines
     elif STARTSWITH_TOP_LEVEL_REGEX.match(logical_line):
         if indent_level:
@@ -353,12 +359,18 @@ def blank_lines(logical_line, blank_lines, indent_level, line_number,
                         "nested definition, found 0"
                 else:
                     yield 0, "E301 expected 1 blank line, found 0"
-        elif blank_before != 2:
-            yield 0, "E302 expected 2 blank lines, found %d" % blank_before
-    elif (logical_line and not indent_level and blank_before != 2 and
-          previous_unindented_logical_line.startswith(('def ', 'class '))):
-        yield 0, "E305 expected 2 blank lines after " \
-            "class or function definition, found %d" % blank_before
+        elif blank_before != top_level_lines:
+            yield 0, "E302 expected %s blank lines, found %d" % (
+                top_level_lines, blank_before)
+    elif (
+        logical_line and
+        not indent_level and
+        blank_before != top_level_lines and
+        previous_unindented_logical_line.startswith(('def ', 'class '))
+            ):
+        yield 0, "E305 expected %s blank lines after " \
+            "class or function definition, found %d" % (
+                top_level_lines, blank_before)
 
 
 @register_check

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -95,6 +95,13 @@ except ImportError:
 PROJECT_CONFIG = ('setup.cfg', 'tox.ini')
 TESTSUITE_PATH = os.path.join(os.path.dirname(__file__), 'testsuite')
 MAX_LINE_LENGTH = 79
+# Number of blank lines between various code parts.
+BLANK_LINES_CONFIG = {
+    # Top level class and function.
+    'top_level': 2,
+    # Methods and nested class and function.
+    'method': 1,
+}
 REPORT_FORMAT = {
     'default': '%(path)s:%(row)d:%(col)d: %(code)s %(text)s',
     'pylint': '%(path)s:%(row)d: [%(code)s] %(text)s',
@@ -328,18 +335,17 @@ def blank_lines(logical_line, blank_lines, indent_level, line_number,
     E305: def a():\n    pass\na()
     E306: def a():\n    def b():\n        pass\n    def c():\n        pass
     """
-    top_level_lines = 3
-    method_lines = 2
+    top_level_lines = BLANK_LINES_CONFIG['top_level']
+    method_lines = BLANK_LINES_CONFIG['method']
 
     if line_number < 3 and not previous_logical:
         return  # Don't expect blank lines before the first line
     if previous_logical.startswith('@'):
         if blank_lines:
             yield 0, "E304 blank lines found after function decorator"
-    elif (
-        blank_lines > method_lines + 1 or
-        (indent_level and blank_lines == method_lines + 1)
-            ):
+    elif (blank_lines > method_lines + 1 or
+            (indent_level and blank_lines == method_lines + 1)
+          ):
         yield 0, "E303 too many blank lines (%d)" % blank_lines
     elif STARTSWITH_TOP_LEVEL_REGEX.match(logical_line):
         if indent_level:
@@ -362,12 +368,11 @@ def blank_lines(logical_line, blank_lines, indent_level, line_number,
         elif blank_before != top_level_lines:
             yield 0, "E302 expected %s blank lines, found %d" % (
                 top_level_lines, blank_before)
-    elif (
-        logical_line and
-        not indent_level and
-        blank_before != top_level_lines and
-        previous_unindented_logical_line.startswith(('def ', 'class '))
-            ):
+    elif (logical_line and
+            not indent_level and
+            blank_before != top_level_lines and
+            previous_unindented_logical_line.startswith(('def ', 'class '))
+          ):
         yield 0, "E305 expected %s blank lines after " \
             "class or function definition, found %d" % (
                 top_level_lines, blank_before)


### PR DESCRIPTION
Scope
====

This is the initial PR for trying to fix #732 

This does not add public configuration, but just extracts the blank lines configuration into variables.

I hope that these changes are helpful and will make the code easier to read.

I am pushing this simple PR to trigger some feedback.

To solve the blank-lines issue, I could ignore all E3XX errors and them register my own blank_lines function which would be a fork from the pycodestyle version.
But I prefer to reduce the level of forking :)


Changes
=======

For a start, it just extracts the variables into a top level dict which can be easily overwritten.

How to test
=========

Tox tests seem ok,  but I don't know how to update the other tests.

If I run pycodedstle on E30not.py it gave me errors in master:

```
$ git top
eb91b79 Ian Stapleton Cordasco 2018-02-17 Merge pull request #684 from jdufresne/async-await
$ pycodestyle testsuite/E30not.py 
testsuite/E30not.py:6:1: E302 expected 2 blank lines, found 1
testsuite/E30not.py:10:1: E302 expected 2 blank lines, found 0
testsuite/E30not.py:14:1: E302 expected 2 blank lines, found 0
testsuite/E30not.py:17:1: E302 expected 2 blank lines, found 0
testsuite/E30not.py:136:1: E302 expected 2 blank lines, found 0
testsuite/E30not.py:162:1: E302 expected 2 blank lines, found 0
(build) 
```