### PR TITLE
Fix support for Python 3.7.

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -413,7 +413,7 @@ def whitespace_around_keywords(logical_line):
             yield match.start(1), "E272 multiple spaces before keyword"
 
         if '\t' in after:
-            yield match.start(2), "E273  tab after keyword"
+            yield match.start(2), "E273 tab after keyword"
         elif len(after) > 1:
             yield match.start(2), "E271 multiple spaces after keyword"
 

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -121,7 +121,7 @@ RAISE_COMMA_REGEX = re.compile(r'raise\s+\w+\s*,')
 RERAISE_COMMA_REGEX = re.compile(r'raise\s+\w+\s*,.*,\s*\w+\s*$')
 ERRORCODE_REGEX = re.compile(r'\b[A-Z]\d{3}\b')
 DOCSTRING_REGEX = re.compile(r'u?r?["\']')
-EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[[({] | []}),;:]')
+EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[\[({] | [\]}),;:]')
 WHITESPACE_AFTER_COMMA_REGEX = re.compile(r'[,;:]\s*(?:  |\t)')
 COMPARE_SINGLETON_REGEX = re.compile(r'(\bNone|\bFalse|\bTrue)?\s*([=!]=)'
                                      r'\s*(?(1)|(None|False|True))\b')

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -413,7 +413,7 @@ def whitespace_around_keywords(logical_line):
             yield match.start(1), "E272 multiple spaces before keyword"
 
         if '\t' in after:
-            yield match.start(2), "E273 tab after keyword"
+            yield match.start(2), "E273  tab after keyword"
         elif len(after) > 1:
             yield match.start(2), "E271 multiple spaces after keyword"
 

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -102,7 +102,7 @@ REPORT_FORMAT = {
 
 PyCF_ONLY_AST = 1024
 SINGLETONS = frozenset(['False', 'None', 'True'])
-KEYWORDS = frozenset(keyword.kwlist + ['print']) - SINGLETONS
+KEYWORDS = frozenset(keyword.kwlist + ['print', 'async']) - SINGLETONS
 UNARY_OPERATORS = frozenset(['>>', '**', '*', '+', '-'])
 ARITHMETIC_OP = frozenset(['**', '*', '/', '//', '+', '-'])
 WS_OPTIONAL_OPERATORS = ARITHMETIC_OP.union(['^', '&', '|', '<<', '>>', '%'])

--- a/testsuite/E25.py
+++ b/testsuite/E25.py
@@ -39,7 +39,7 @@ def munge(input: AnyStr, sep: AnyStr = None, limit=1000,
 async def add(a: int = 0, b: int = 0) -> int:
     return a + b
 # Previously E251 four times
-#: E272:1:6
+#: E271:1:6
 async  def add(a: int = 0, b: int = 0) -> int:
     return a + b
 #: E252:1:15 E252:1:16 E252:1:27 E252:1:36

--- a/testsuite/E30.py
+++ b/testsuite/E30.py
@@ -157,7 +157,7 @@ def main():
 if __name__ == '__main__':
     main()
 # Previously just E272:1:6 E272:4:6
-#: E302:4:1 E272:1:6 E272:4:6
+#: E302:4:1 E271:1:6 E271:4:6
 async  def x():
     pass
 

--- a/testsuite/E70.py
+++ b/testsuite/E70.py
@@ -14,7 +14,7 @@ del a[:]; a.append(42);
 def f(x): return 2
 #: E704:1:1
 async def f(x): return 2
-#: E704:1:1 E272:1:6
+#: E704:1:1 E271:1:6
 async  def f(x): return 2
 #: E704:1:1 E226:1:19
 def f(x): return 2*x


### PR DESCRIPTION
Scope
=====

This started as a fix for the #728 issue, where we got a warning and tests are failing on python 3.7.

But I have retargeted for the whole python 3.7


Why we got this
============

In python 3.7 we got `async` keyword.


Changes
=======

Just explicitly escape the nested brackets. I went for escaping both the start and the end.



How to test
==========

Give it a try on Python 3.7... but I hope that Travis-CI will help with the tests.