### PR TITLE
Ignore length of shebang line

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -260,7 +260,8 @@ def trailing_blank_lines(physical_line, lines, line_number, total_lines):
 
 
 @register_check
-def maximum_line_length(physical_line, max_line_length, multiline, noqa):
+def maximum_line_length(physical_line, max_line_length, multiline,
+                        line_number, noqa):
     r"""Limit all lines to a maximum of 79 characters.
 
     There are still many devices around that are limited to 80 character
@@ -275,6 +276,9 @@ def maximum_line_length(physical_line, max_line_length, multiline, noqa):
     line = physical_line.rstrip()
     length = len(line)
     if length > max_line_length and not noqa:
+        # Special case: ignore long shebang lines.
+        if line_number == 1 and length > 1 and line[:2] == '#!':
+            return
         # Special case for long URLs in multi-line docstrings or comments,
         # but still report the error when the 72 first chars are whitespaces.
         chunks = line.split()

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -277,7 +277,7 @@ def maximum_line_length(physical_line, max_line_length, multiline,
     length = len(line)
     if length > max_line_length and not noqa:
         # Special case: ignore long shebang lines.
-        if line_number == 1 and length > 1 and line[:2] == '#!':
+        if line_number == 1 and line.startswith('#!'):
             return
         # Special case for long URLs in multi-line docstrings or comments,
         # but still report the error when the 72 first chars are whitespaces.

--- a/testsuite/E50.py
+++ b/testsuite/E50.py
@@ -121,3 +121,7 @@ import this
 #: E501
 # This
 #                                                                       almost_empty_line
+
+#
+#: Okay
+#!/reallylongpath/toexecutable --maybe --with --some ARGUMENTS TO DO WITH WHAT EXECUTABLE TO RUN


### PR DESCRIPTION
Add check to avoid long line error on shebang lines (as discussed in [Issue 734](https://github.com/PyCQA/pycodestyle/issues/734)), and a test for this behaviour.