### PR TITLE
Add changelog items for 2.3.1...master

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -27,7 +27,7 @@ Changes:
 * You can now write 'pycodestyle.StyleGuide(verbose=True)' instead of
   'pycodestyle.StyleGuide(verbose=True, paths=['-v'])' in order to achieve
   verbosity.
-* The distribution of pycodestyle now includes the licence text in order to
+* The distribution of pycodestyle now includes the license text in order to
   comply with open source licenses which require this.
 * 'maximum_line_length' now ignores shebang ('#!') lines.
 * Add configuration option for the allowed number of blank lines. It is

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,46 +7,46 @@ UNRELEASED
 New checks:
 
 * Add W504 warning for checking that a break doesn't happen after a binary
-  operator. This check is ignored by default.
-* Add W605 warning for invalid escape sequences in string literals.
+  operator. This check is ignored by default. PR #502.
+* Add W605 warning for invalid escape sequences in string literals. PR #676.
 * Add W606 warning for 'async' and 'await' reserved keywords being introduced
-  in Python 3.7.
+  in Python 3.7. PR #684.
 * Add E252 error for missing whitespace around equal sign in type annotated
-  function arguments with defaults values.
+  function arguments with defaults values. PR #717.
 
 Changes:
 
 * An internal bisect search has replaced a linear search in order to improve
-  efficiency.
+  efficiency. PR #648.
 * pycodestyle now uses PyPI trove classifiers in order to document supported
-  python versions on PyPI.
+  python versions on PyPI. PR #654.
 * 'setup.cfg' '[wheel]' section has been renamed to '[bdist_wheel]', as
-  the former is legacy.
+  the former is legacy. PR #653.
 * pycodestyle now handles very long lines much more efficiently for python
-  3.2+. Fixes #643.
+  3.2+. Fixes #643. PR #644.
 * You can now write 'pycodestyle.StyleGuide(verbose=True)' instead of
   'pycodestyle.StyleGuide(verbose=True, paths=['-v'])' in order to achieve
-  verbosity.
+  verbosity. PR #663.
 * The distribution of pycodestyle now includes the license text in order to
-  comply with open source licenses which require this.
-* 'maximum_line_length' now ignores shebang ('#!') lines.
+  comply with open source licenses which require this. PR #694.
+* 'maximum_line_length' now ignores shebang ('#!') lines. PR #736.
 * Add configuration option for the allowed number of blank lines. It is
   implemented as a top level dictionary which can be easily overwritten. Fixes
-  #732.
+  #732. PR #733.
 
 Bugs:
 
 * Prevent a 'DeprecationWarning', and a 'SyntaxError' in future python, caused
-  by an invalid escape sequence.
+  by an invalid escape sequence. PR #625.
 * Correctly report E501 when the first line of a docstring is too long.
-  Resolves #622.
+  Resolves #622. PR #630.
 * Support variable annotation when variable start by a keyword, such as class
-  variable type annotations in python 3.6.
+  variable type annotations in python 3.6. PR #640.
 * pycodestyle internals have been changed in order to allow 'python3 -m
-  cProfile' to report correct metrics.
-* Fix a spelling mistake in the description of E722.
+  cProfile' to report correct metrics. PR #647.
+* Fix a spelling mistake in the description of E722. PR #697.
 * 'pycodestyle --diff' now does not break if your 'gitconfig' enables
-  'mnemonicprefix'.
+  'mnemonicprefix'. PR #706.
 
 2.3.1 (2017-01-31)
 ------------------

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,10 +7,46 @@ UNRELEASED
 New checks:
 
 * Add W504 warning for checking that a break doesn't happen after a binary
-  operator. This check is ignored by default
-* Add W605 warning for invalid escape sequences in string literals
+  operator. This check is ignored by default.
+* Add W605 warning for invalid escape sequences in string literals.
 * Add W606 warning for 'async' and 'await' reserved keywords being introduced
-  in Python 3.7
+  in Python 3.7.
+* Add E252 error for missing whitespace around equal sign in type annotated
+  function arguments with defaults values.
+
+Changes:
+
+* An internal bisect search has replaced a linear search in order to improve
+  efficiency.
+* pycodestyle now uses PyPI trove classifiers in order to document supported
+  python versions on PyPI.
+* 'setup.cfg' '[wheel]' section has been renamed to '[bdist_wheel]', as
+  the former is legacy.
+* pycodestyle now handles very long lines much more efficiently for python
+  3.2+. Fixes #643.
+* You can now write 'pycodestyle.StyleGuide(verbose=True)' instead of
+  'pycodestyle.StyleGuide(verbose=True, paths=['-v'])' in order to achieve
+  verbosity.
+* The distribution of pycodestyle now includes the licence text in order to
+  comply with open source licenses which require this.
+* 'maximum_line_length' now ignores shebang ('#!') lines.
+* Add configuration option for the allowed number of blank lines. It is
+  implemented as a top level dictionary which can be easily overwritten. Fixes
+  #732.
+
+Bugs:
+
+* Prevent a 'DeprecationWarning', and a 'SyntaxError' in future python, caused
+  by an invalid escape sequence.
+* Correctly report E501 when the first line of a docstring is too long.
+  Resolves #622.
+* Support variable annotation when variable start by a keyword, such as class
+  variable type annotations in python 3.6.
+* pycodestyle internals have been changed in order to allow 'python3 -m
+  cProfile' to report correct metrics.
+* Fix a spelling mistake in the description of E722.
+* 'pycodestyle --diff' now does not break if your 'gitconfig' enables
+  'mnemonicprefix'.
 
 2.3.1 (2017-01-31)
 ------------------


### PR DESCRIPTION
I have updated the changelog to reflect all the changes since the last PyPI release in order to allow master to reach a publishable state.

I tried to filter out any changes that have no end-user impact, but I was still quite liberal in what I included into the list. If there is anything which is a bit too granular I can remove it.

Thanks!