### PR TITLE
Change the position pointed out by W605

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1524,7 +1524,7 @@ def python_3000_invalid_escape_sequence(logical_line, tokens):
                     pos += 1
                     if string[pos] not in valid:
                         yield (
-                            pos,
+                            line.lstrip().find(text),
                             "W605 invalid escape sequence '\\%s'" %
                             string[pos],
                         )


### PR DESCRIPTION
test environment:
```
$ python -V
Python 3.6.5
$ pycodestyle --version
2.4.0
```
input file:
```python
# target.py
regex = ('hello', "\.png$")


def main():
    regex = ('hello', "\.png$")
```

before:
```
target.py:1:2: W605 invalid escape sequence '\.'
regex = ('hello', "\.png$")
 ^
    Invalid escape sequences are deprecated in Python 3.6.

    Okay: regex = r'\.png$'
    W605: regex = '\.png$'
target.py:5:6: W605 invalid escape sequence '\.'
    regex = ('hello', "\.png$")
     ^
    Invalid escape sequences are deprecated in Python 3.6.

    Okay: regex = r'\.png$'
    W605: regex = '\.png$'
```

after:
```
target.py:1:19: W605 invalid escape sequence '\.'
regex = ('hello', "\.png$")
                  ^
    Invalid escape sequences are deprecated in Python 3.6.

    Okay: regex = r'\.png$'
    W605: regex = '\.png$'
target.py:5:23: W605 invalid escape sequence '\.'
    regex = ('hello', "\.png$")
                      ^
    Invalid escape sequences are deprecated in Python 3.6.

    Okay: regex = r'\.png$'
    W605: regex = '\.png$'
```

Thanks.