### PR TITLE
Change the position pointed out by W504

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1266,7 +1266,7 @@ def break_after_binary_operator(logical_line, tokens):
     Okay: var = (1 /\n       -2)
     Okay: var = (1 +\n       -1 +\n       -2)
     """
-    old_start = None
+    prev_start = None
     for context in _break_around_binary_operators(tokens):
         (token_type, text, previous_token_type, previous_text,
          line_break, unary_context, start) = context
@@ -1274,8 +1274,8 @@ def break_after_binary_operator(logical_line, tokens):
                 line_break and
                 not unary_context and
                 not _is_binary_operator(token_type, text)):
-            yield old_start, "W504 line break after binary operator"
-        old_start = start
+            yield prev_start, "W504 line break after binary operator"
+        prev_start = start
 
 
 @register_check

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1266,6 +1266,7 @@ def break_after_binary_operator(logical_line, tokens):
     Okay: var = (1 /\n       -2)
     Okay: var = (1 +\n       -1 +\n       -2)
     """
+    old_start = None
     for context in _break_around_binary_operators(tokens):
         (token_type, text, previous_token_type, previous_text,
          line_break, unary_context, start) = context
@@ -1273,8 +1274,8 @@ def break_after_binary_operator(logical_line, tokens):
                 line_break and
                 not unary_context and
                 not _is_binary_operator(token_type, text)):
-            error_pos = (start[0] - 1, start[1])
-            yield error_pos, "W504 line break after binary operator"
+            yield old_start, "W504 line break after binary operator"
+        old_start = start
 
 
 @register_check


### PR DESCRIPTION
test environment:
```
$ python -V
Python 3.6.5
$ pycodestyle --version
2.4.0
$ pycodestyle --select=W --show-source target.py
```

input:
```python
var = (1 &     # comment
       ~2)
(width == 0 and
 height == 0)
```

before:
```
target.py:1:8: W504 line break after binary operator
var = (1 &     # comment
       ^
target.py:3:2: W504 line break after binary operator
(width == 0 and
 ^
```

after:
```
target.py:1:10: W504 line break after binary operator
var = (1 &     # comment
         ^
target.py:3:13: W504 line break after binary operator
(width == 0 and
            ^
```

Thanks