### PR TITLE
Making pycodestyle faster

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1770,6 +1770,8 @@ class Checker(object):
         self.filename = filename
         # Dictionary where a checker can store its custom state.
         self._checker_states = {}
+        self.checker_state = self._checker_states.setdefault(
+            'module_imports_on_top_of_file', {})
         if filename is None:
             self.filename = 'stdin'
             self.lines = lines or []
@@ -1819,16 +1821,10 @@ class Checker(object):
             self.indent_char = line[0]
         return line
 
-    def init_checker_state(self, name, argument_names):
-        """Prepare custom state for the specific checker plugin."""
-        if 'checker_state' in argument_names:
-            self.checker_state = self._checker_states.setdefault(name, {})
-
     def check_physical(self, line):
         """Run all physical checks on a raw input line."""
         self.physical_line = line
         for name, check, argument_names in self._physical_checks:
-            self.init_checker_state(name, argument_names)
             result = check(self)
             if result is not None:
                 (offset, text) = result
@@ -1887,7 +1883,6 @@ class Checker(object):
         for name, check, argument_names in self._logical_checks:
             if self.verbose >= 4:
                 print('   ' + name)
-            self.init_checker_state(name, argument_names)
             for offset, text in check(self) or ():
                 if not isinstance(offset, tuple):
                     # As mappings are ordered, bisecting is a fast way

--- a/testsuite/support.py
+++ b/testsuite/support.py
@@ -111,7 +111,7 @@ def selftest(options):
     report = BaseReport(options)
     counters = report.counters
     checks = options.physical_checks + options.logical_checks
-    for name, check, argument_names in checks:
+    for name, check in checks:
         for line in check.__doc__.splitlines():
             line = line.lstrip()
             match = SELFTEST_REGEX.match(line)

--- a/testsuite/test_api.py
+++ b/testsuite/test_api.py
@@ -42,43 +42,46 @@ class APITestCase(unittest.TestCase):
         del sys.stdout[:], sys.stderr[:]
 
     def test_register_physical_check(self):
-        def check_dummy(physical_line, line_number):
+        def check_dummy(self):
             if False:
                 yield
-        pycodestyle.register_check(check_dummy, ['Z001'])
+        pycodestyle.register_check("physical_line", "line_number")(
+            check_dummy, ['Z001'])
 
         self.assertTrue(check_dummy in pycodestyle._checks['physical_line'])
         codes, args = pycodestyle._checks['physical_line'][check_dummy]
         self.assertTrue('Z001' in codes)
-        self.assertEqual(args, ['physical_line', 'line_number'])
+        self.assertEqual(args, ('physical_line', 'line_number'))
 
         options = pycodestyle.StyleGuide().options
         self.assertTrue(any(func == check_dummy
                             for name, func, args in options.physical_checks))
 
     def test_register_logical_check(self):
-        def check_dummy(logical_line, tokens):
+        def check_dummy(self):
             if False:
                 yield
-        pycodestyle.register_check(check_dummy, ['Z401'])
+        pycodestyle.register_check("logical_line", "tokens")(
+            check_dummy, ['Z401'])
 
         self.assertTrue(check_dummy in pycodestyle._checks['logical_line'])
         codes, args = pycodestyle._checks['logical_line'][check_dummy]
         self.assertTrue('Z401' in codes)
-        self.assertEqual(args, ['logical_line', 'tokens'])
+        self.assertEqual(args, ('logical_line', 'tokens'))
 
-        pycodestyle.register_check(check_dummy, [])
-        pycodestyle.register_check(check_dummy, ['Z402', 'Z403'])
+        pycodestyle.register_check("logical_line", "tokens")(check_dummy, [])
+        pycodestyle.register_check("logical_line", "tokens")(
+            check_dummy, ['Z402', 'Z403'])
         codes, args = pycodestyle._checks['logical_line'][check_dummy]
         self.assertEqual(codes, ['Z401', 'Z402', 'Z403'])
-        self.assertEqual(args, ['logical_line', 'tokens'])
+        self.assertEqual(args, ('logical_line', 'tokens'))
 
         options = pycodestyle.StyleGuide().options
         self.assertTrue(any(func == check_dummy
                             for name, func, args in options.logical_checks))
 
     def test_register_ast_check(self):
-        pycodestyle.register_check(DummyChecker, ['Z701'])
+        pycodestyle.register_check("tree", "filename")(DummyChecker, ['Z701'])
 
         self.assertTrue(DummyChecker in pycodestyle._checks['tree'])
         codes, args = pycodestyle._checks['tree'][DummyChecker]
@@ -97,14 +100,14 @@ class APITestCase(unittest.TestCase):
         def check_dummy(logical, tokens):
             if False:
                 yield
-        pycodestyle.register_check(InvalidChecker, ['Z741'])
-        pycodestyle.register_check(check_dummy, ['Z441'])
+        pycodestyle.register_check("filename")(InvalidChecker, ['Z741'])
+        pycodestyle.register_check("filename")(check_dummy, ['Z441'])
 
         for checkers in pycodestyle._checks.values():
             self.assertTrue(DummyChecker not in checkers)
             self.assertTrue(check_dummy not in checkers)
 
-        self.assertRaises(TypeError, pycodestyle.register_check)
+        self.assertRaises(TypeError, pycodestyle.register_check("filename"))
 
     def test_styleguide(self):
         report = pycodestyle.StyleGuide().check_files()
@@ -320,7 +323,7 @@ class APITestCase(unittest.TestCase):
 
     def test_check_unicode(self):
         # Do not crash if lines are Unicode (Python 2.x)
-        pycodestyle.register_check(DummyChecker, ['Z701'])
+        pycodestyle.register_check("tree", "filename")(DummyChecker, ['Z701'])
         source = '#\n'
         if hasattr(source, 'decode'):
             source = source.decode('ascii')
@@ -333,7 +336,7 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(count_errors, 0)
 
     def test_check_nullbytes(self):
-        pycodestyle.register_check(DummyChecker, ['Z701'])
+        pycodestyle.register_check("tree", "filename")(DummyChecker, ['Z701'])
 
         pep8style = pycodestyle.StyleGuide()
         count_errors = pep8style.input_file('stdin', lines=['\x00\n'])
@@ -354,7 +357,7 @@ class APITestCase(unittest.TestCase):
         self.assertEqual(count_errors, 1)
 
     def test_styleguide_unmatched_triple_quotes(self):
-        pycodestyle.register_check(DummyChecker, ['Z701'])
+        pycodestyle.register_check("tree", "filename")(DummyChecker, ['Z701'])
         lines = [
             'def foo():\n',
             '    """test docstring""\'\n',
@@ -368,7 +371,7 @@ class APITestCase(unittest.TestCase):
         self.assertTrue(expected in stdout)
 
     def test_styleguide_continuation_line_outdented(self):
-        pycodestyle.register_check(DummyChecker, ['Z701'])
+        pycodestyle.register_check("tree", "filename")(DummyChecker, ['Z701'])
         lines = [
             'def foo():\n',
             '    pass\n',


### PR DESCRIPTION
I've been on a Python performance optimization kick recently (see
https://github.com/PyCQA/astroid/pull/497), and I'm a `pycodestyle`
user, so I figured I would give it a look and see if its performance
could be improved at all.

Of course, `pycodestyle` is already pretty fast, so to give it some
stress I'm testing it out by pointing it right at a large repo, namely
Zulip (https://github.com/zulip/zulip). In particular, my test command
is `time ~/pycodestyle/pycodestyle.py -qq ~/zulip`.

Here are the times from three runs of master:

```
real	2m10.664s
user	0m55.333s
sys	1m15.249s

real	2m11.376s
user	0m55.545s
sys	1m15.745s

real	2m11.588s
user	0m55.500s
sys	1m16.044s

```

I used the `yappi` profiling library to see if there were any hotspots
in the code. There were. Take a look at the graph below. The brighter
the box, the hotter the spot. In more detail, each box represents a
function and has three numbers: 1) the percentage of total CPU time
spent in that function, 2) the percentage of total CPU time spent in
that function but not its subcalls, and 3) the number of times the
function was called.

![pcs-master](https://user-images.githubusercontent.com/17630138/38784585-9c0b9c12-40d9-11e8-9cf0-7927edd71896.png)

The red box that sticks out is `Checker.run_check`. It is called well
over two million times, and 27.7 of total CPU time is spent there,
almost all over which is in the function itself. This seems like an
awful lot considering how short the function is:

```
    def run_check(self, check, argument_names):
        """Run a check plugin."""
        arguments = []
        for name in argument_names:
            arguments.append(getattr(self, name))
        return check(*arguments)
```

So why does it suck up so much time?

I think I've worked out how it goes. When a check is registered (with
`register_check`), its arguments are extracted with the `inspect`
library and stored as a list of strings. When a check is run,
`run_check` iterates over its associated list of arguments,
dynamically accesses those attributes of the `Checker`, and then
passes those values to the check to actually run.

The problem here is that dynamic attribute access is slow, and doing
it in tight loops is really slow (see
https://github.com/PyCQA/astroid/pull/497 for a harrowing cautionary
tale on this subject). My idea was to see if there was a way to do
away with the dynamic attribute access, basically by "compiling" the
attribute access into the code.

It turns out that this can be accomplished by passing the checker
instance into the check as an argument, and then call the attributes
directly on the checker. Implementing this change involves a
large-scale shuffling of arguments and strings, but other than that
not much changes. `register_check` has to take the check's argument
names as arguments now, since they are no longer the actual arguments.
`run_check` itself can also be done away with, since all it would have
to do would be to call the check with the checker as an argument, and
that can be done inline.

This change resulted in a substantial speedup:

```
real	1m28.057s
user	0m40.340s
sys	0m47.669s

real	1m27.843s
user	0m39.910s
sys	0m47.901s

real	1m28.258s
user	0m40.379s
sys	0m47.849s
```

Here is the resulting `yappi` graph:

![pcs-check](https://user-images.githubusercontent.com/17630138/38784588-ab9b00a0-40d9-11e8-80b2-f8016fd1e6cb.png)

This graph is a lot more colorful than the last one. This means that
the work is spread out more evenly among the various functions and
there isn't one overwhelmingly critical hotspot.

One function that stuck out to me was `Checker.init_checker_state`.
After some experimentation, it appeared that despite taking up almost
6% of total CPU time, the function didn't do much. Cutting it provided
a non-negligible speed improvement:

```
real	1m19.463s
user	0m36.857s
sys	0m42.565s

real	1m19.837s
user	0m36.469s
sys	0m43.329s

real	1m19.521s
user	0m36.462s
sys	0m43.026s

```

A little further poking around revealed that `run_check` and
`init_checker_state` were the only consumers of the "argument names",
so I cut those out too. This led to some nice code simplification and
an ever-so-slight speedup:

```
real	1m19.686s
user	0m36.516s
sys	0m43.129s

real	1m18.466s
user	0m36.196s
sys	0m42.227s

real	1m19.063s
user	0m36.188s
sys	0m42.846s
```

Here is the `yappi` graph after these changes:

![pcs-check-init](https://user-images.githubusercontent.com/17630138/38784592-b65a5a04-40d9-11e8-9806-975b84cb0c28.png)

The major hotspot is now `tokenize.tokenize`, which is part of the
standard library. This is good, as it suggests that `pycodestyle` is
nearing the point of being as fast as it can be. After that, the next
most expensive functions are

* `check_logical`,
* `generate_tokens`,
* `build_tokens_line`,
* `check_all`,
* `maybe_check_physical`, and
* `_is_eol_token_`.

These functions all feel to me like they are doing something
inefficiently, but I don't understand them well enough to say what.

These measurements were all taken running master with

```
Python 3.6.5 (default, Mar 30 2018, 06:42:10)
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)] on darwin
```
