### PR TITLE
Update all pypi.python.org URLs to pypi.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -10,7 +10,7 @@ pycodestyle (formerly called pep8) - Python style guide checker
     :alt: Documentation Status
 
 .. image:: https://img.shields.io/pypi/wheel/pycodestyle.svg
-   :target: https://pypi.python.org/pypi/pycodestyle
+   :target: https://pypi.org/project/pycodestyle/
    :alt: Wheel Status
 
 .. image:: https://badges.gitter.im/PyCQA/pycodestyle.svg

--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -43,8 +43,8 @@ Among other things, these features are currently not in the scope of
 the ``pycodestyle`` library:
 
 * **naming conventions**: this kind of feature is supported through plugins.
-  Install `flake8 <https://pypi.python.org/pypi/flake8>`_ and the
-  `pep8-naming extension <https://pypi.python.org/pypi/pep8-naming>`_ to use
+  Install `flake8 <https://pypi.org/project/flake8/>`_ and the
+  `pep8-naming extension <https://pypi.org/project/pep8-naming/>`_ to use
   this feature.
 * **docstring conventions**: they are not in the scope of this library;
   see the `pydocstyle project <https://github.com/PyCQA/pydocstyle>`_.


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html