### PR TITLE
Remove suggestion and documentation of using unmaintained nose

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -69,7 +69,6 @@ GitHub has an excellent `guide`_.
 The current tests are written in 2 styles:
 
 * standard xUnit based only on stdlib unittest
-  (can be executed with nose)
 * functional test using a custom framework and executed by the
   pycodestyle itself when installed in dev mode.
 
@@ -77,19 +76,12 @@ The current tests are written in 2 styles:
 Running unittest
 ~~~~~~~~~~~~~~~~
 
-While the tests are writted using stdlib `unittest` module, the existing
-test include unit, integration and functional tests.
+The tests are writted using stdlib `unittest` module, the existing test
+include unit, integration and functional tests.
 
-There are a couple of ways to run the tests::
+To run the tests::
 
     $ python setup.py test
-    $ # Use nose to run specific test
-    $ nosetests \
-    >    testsuite.test_blank_lines:TestBlankLinesDefault.test_initial_no_blank
-    $ # Use nose to run a subset and check coverage, and check the resulting
-    $ $ cover/pycodestyle_py.html in your browser
-    $ nosetests --with-coverage --cover-html -s testsuite.test_blank_lines
-
 
 Running functional
 ~~~~~~~~~~~~~~~~~~

--- a/docs/advanced.rst
+++ b/docs/advanced.rst
@@ -25,9 +25,6 @@ in your project::
           self.assertEqual(result.total_errors, 0,
                            "Found code style errors (and warnings).")
 
-If you are using ``nosetests`` for running tests, remove ``quiet=True``
-since Nose suppresses stdout.
-
 There's also a shortcut for checking a single file::
 
   import pycodestyle

--- a/testsuite/support.py
+++ b/testsuite/support.py
@@ -215,7 +215,3 @@ def run_tests(style):
     if options.testsuite:
         init_tests(style)
     return style.check_files()
-
-
-# nose should not collect these functions
-init_tests.__test__ = run_tests.__test__ = False


### PR DESCRIPTION
The nose project has ceased development. The last commit is from Mar 3, 2016. From their docs page:

https://nose.readthedocs.io/

> Note to Users
>
> Nose has been in maintenance mode for the past several years and will likely cease without a new person/team to take over maintainership.New projects should consider using Nose2, py.test, or just plain unittest/unittest2.