### PR TITLE
refs W606, only NAME can follow await

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1580,7 +1580,7 @@ def python_3000_async_await_keywords(logical_line, tokens):
             else:
                 error = True
         elif state[0] == 'await':
-            if token_type in (tokenize.NAME, tokenize.NUMBER, tokenize.STRING):
+            if token_type == tokenize.NAME:
                 # An await expression. Return to looking for async/await
                 # names.
                 state = None

--- a/testsuite/W60.py
+++ b/testsuite/W60.py
@@ -45,6 +45,10 @@ async = 42
 #: W606
 await = 42
 #: W606
+await 42
+#: W606
+await 'test'
+#: W606
 def async():
     pass
 #: W606


### PR DESCRIPTION
`await NUMBER` or `await STRING` is not valid syntax

@jdufresne could you help on this? If I miss some cases, I'll add NUMBER/STRING to tests