### PR TITLE
Use 'dist: xenial' in Travis to simplify configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: python
 cache: pip
 sudo: false
@@ -16,10 +17,10 @@ matrix:
       env: TOXENV=py36
     - python: 3.7
       env: TOXENV=py37
-      dist: xenial
-      sudo: true
-    - python: pypy
+    - python: pypy2.7-6.0
       env: TOXENV=pypy
+    - python: pypy3.5-6.0
+      env: TOXENV=pypy3
     - python: 3.5
       env: TOXENV=flake8
 


### PR DESCRIPTION
Allows using Python version 3.7 without sudo declarations.

Travis officially added support for Xenial on 2018-11-08.

https://blog.travis-ci.com/2018-11-08-xenial-release