### PR TITLE
BaseReport Messages Include Error Row and Column Info

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -2134,7 +2134,7 @@ class BaseReport(object):
         self.elapsed = 0
         self.total_errors = 0
         self.counters = dict.fromkeys(self._benchmark_keys, 0)
-        self.messages = {}
+        self.messages = []
 
     def start(self):
         """Start the timer."""
@@ -2167,7 +2167,8 @@ class BaseReport(object):
             self.counters[code] += 1
         else:
             self.counters[code] = 1
-            self.messages[code] = text[5:]
+            #self.messages[code] = text[5:]
+            self.messages.append((line_number, offset, code, text[5:]))
         # Don't care about expected errors or warnings
         if code in self.expected:
             return
@@ -2183,8 +2184,7 @@ class BaseReport(object):
 
     def get_count(self, prefix=''):
         """Return the total count of errors and warnings."""
-        return sum(self.counters[key]
-                   for key in self.messages if key.startswith(prefix))
+        return len(self.messages)
 
     def get_statistics(self, prefix=''):
         """Get statistics for message codes that start with the prefix.
@@ -2194,8 +2194,8 @@ class BaseReport(object):
         prefix='W' matches all warnings
         prefix='E4' matches all errors that have to do with imports
         """
-        return ['%-7s %s %s' % (self.counters[key], key, self.messages[key])
-                for key in sorted(self.messages) if key.startswith(prefix)]
+        return ['%-7s %s %s' % (self.counters[key[2]], key[2], key[3])
+                for key in sorted(self.messages) if key[2].startswith(prefix)]
 
     def print_statistics(self, prefix=''):
         """Print overall statistics (number of errors and warnings)."""

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -2167,7 +2167,6 @@ class BaseReport(object):
             self.counters[code] += 1
         else:
             self.counters[code] = 1
-            #self.messages[code] = text[5:]
             self.messages.append((line_number, offset, code, text[5:]))
         # Don't care about expected errors or warnings
         if code in self.expected:

--- a/testsuite/test_all.py
+++ b/testsuite/test_all.py
@@ -43,7 +43,7 @@ class PycodestyleTestCase(unittest.TestCase):
                  os.path.join(ROOT_DIR, 'setup.py')]
         report = self._style.init_report(pycodestyle.StandardReport)
         report = self._style.check_files(files)
-        self.assertEqual(list(report.messages.keys()), ['W504'],
+        self.assertEqual(report.messages[0][2], 'W504',
                          msg='Failures: %s' % report.messages)
 
 


### PR DESCRIPTION
BaseReport (used when quiet option is specified) does not include row and column numbers or other useful error info. Being able to access this info even when quiet mode is enabled may be useful for some.

**UseCase:** User does not want the pep8 check error printed to stdout so they enable quiet mode. User may still want to retrieve errors from BaseReport messages within a python script that checks jupyter notebook code cells for pep8 errors and generate reports for CI.

**Changes:**

- Updated base report messages to a list instead of a dictionary. Stores tuples for error info.
- Updated methods to print and get statistics fro BaseReport to work with new messages format.
- Updated test_own_dog_food unit test to verify assertion on list of tuple instead of dictionary.