### PR TITLE
Allow spaces before lambda.

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -141,7 +141,7 @@ COMPARE_SINGLETON_REGEX = re.compile(r'(\bNone|\bFalse|\bTrue)?\s*([=!]=)'
 COMPARE_NEGATIVE_REGEX = re.compile(r'\b(not)\s+[^][)(}{ ]+\s+(in|is)\s')
 COMPARE_TYPE_REGEX = re.compile(r'(?:[=!]=|is(?:\s+not)?)\s+type(?:s.\w+Type'
                                 r'|\s*\(\s*([^)]*[^ )])\s*\))')
-KEYWORD_REGEX = re.compile(r'(\s*)\b(?:%s)\b(\s*)' % r'|'.join(KEYWORDS))
+KEYWORD_REGEX = re.compile(r'(\s*)\b(%s)\b(\s*)' % r'|'.join(KEYWORDS))
 OPERATOR_REGEX = re.compile(r'(?:[^,\s])(\s*)(?:[-+*/|!<=>%&^]+)(\s*)')
 LAMBDA_REGEX = re.compile(r'\blambda\b')
 HUNK_REGEX = re.compile(r'^@@ -\d+(?:,\d+)? \+(\d+)(?:,(\d+))? @@.*$')
@@ -447,17 +447,17 @@ def whitespace_around_keywords(logical_line):
     E274: True\tand False
     """
     for match in KEYWORD_REGEX.finditer(logical_line):
-        before, after = match.groups()
+        before, kw, after = match.groups()
 
-        if '\t' in before:
+        if '\t' in before and kw != "lambda":
             yield match.start(1), "E274 tab before keyword"
-        elif len(before) > 1:
+        elif len(before) > 1 and kw != "lambda":
             yield match.start(1), "E272 multiple spaces before keyword"
 
         if '\t' in after:
-            yield match.start(2), "E273 tab after keyword"
+            yield match.start(3), "E273 tab after keyword"
         elif len(after) > 1:
-            yield match.start(2), "E271 multiple spaces after keyword"
+            yield match.start(3), "E271 multiple spaces after keyword"
 
 
 @register_check

--- a/testsuite/E27.py
+++ b/testsuite/E27.py
@@ -42,3 +42,8 @@ try:
     from importable.module import(e, f)
 except ImportError:
     pass
+#: E241
+{  # (but no E272)
+    "key":        lambda: None,
+    "longer-key": lambda: None,
+}


### PR DESCRIPTION
Currently, pycodestyle allows
```
{
    "key":        1,
    "longer-key": 2,
}
```
(actually it emits a E241 "multiple spaces after ":", but that's
suppressed by default) but disallows
```
{
    "key":        lambda: 1,
    "longer-key": lambda: 2,
}
```
because the first entry has "multiple spaces before keyword" (before the
lambda), even though the cases are clearly similar.

Fix that by excluding lambda from that check.