### PR TITLE
Structured reporter

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -2321,6 +2321,104 @@ class DiffReport(StandardReport):
         return super(DiffReport, self).error(line_number, offset, text, check)
 
 
+class ListReport(object):
+    """Collect the results of the checks into a structured
+    list of dictionary entries."""
+
+    def __init__(self, options):
+        self._benchmark_keys = options.benchmark_keys
+        self._ignore_code = options.ignore_code
+        # Results
+        self.elapsed = 0
+        self.total_errors = 0
+        self.counters = dict.fromkeys(self._benchmark_keys, 0)
+        self.messages = {}
+        self.entries = []
+
+    def start(self):
+        """Start the timer."""
+        self._start_time = time.time()
+
+    def stop(self):
+        """Stop the timer."""
+        self.elapsed = time.time() - self._start_time
+
+    def init_file(self, filename, lines, expected, line_offset):
+        """Signal a new file."""
+        self.filename = filename
+        self.lines = lines
+        self.expected = expected or ()
+        self.line_offset = line_offset
+        self.file_errors = 0
+        self.counters['files'] += 1
+        self.counters['physical lines'] += len(lines)
+
+    def increment_logical_line(self):
+        """Signal a new logical line."""
+        self.counters['logical lines'] += 1
+
+    def error(self, line_number, offset, text, check):
+        """Report an error, according to options."""
+        code = text[:4]
+        if self._ignore_code(code):
+            return
+        if code in self.counters:
+            self.counters[code] += 1
+        else:
+            self.counters[code] = 1
+            self.messages[code] = text[5:]
+        # Don't care about expected errors or warnings
+        if code in self.expected:
+            return
+
+        self.entries.append({"message_class": "error",
+                             "message_code": code,
+                             "filename": self.filename,
+                             "lineno": line_number,
+                             "offset": offset,
+                             "message": text[5:],
+                             "source": self.lines[line_number],
+                             })
+
+        self.file_errors += 1
+        self.total_errors += 1
+        return code
+
+    def get_file_results(self):
+        """Return the count of errors and warnings for this file."""
+        return self.file_errors
+
+    def get_count(self, prefix=''):
+        """Return the total count of errors and warnings."""
+        return sum(self.counters[key]
+                   for key in self.messages if key.startswith(prefix))
+
+    def get_statistics(self, prefix=''):
+        """Get statistics for message codes that start with the prefix.
+
+        prefix='' matches all errors and warnings
+        prefix='E' matches all errors
+        prefix='W' matches all warnings
+        prefix='E4' matches all errors that have to do with imports
+        """
+        return ['%-7s %s %s' % (self.counters[key], key, self.messages[key])
+                for key in sorted(self.messages) if key.startswith(prefix)]
+
+    def print_statistics(self, prefix=''):
+        """Print overall statistics (number of errors and warnings)."""
+        for line in self.get_statistics(prefix):
+            print(line)
+
+    def print_benchmark(self):
+        """Print benchmark numbers."""
+        print('%-7.2f %s' % (self.elapsed, 'seconds elapsed'))
+        if self.elapsed:
+            for key in self._benchmark_keys:
+                print('%-7d %s per second (%d total)' %
+                      (self.counters[key] / self.elapsed, key,
+                       self.counters[key]))
+
+
 class StyleGuide(object):
     """Initialize a PEP-8 instance with few options."""
 

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -2377,7 +2377,7 @@ class ListReport(object):
                              "lineno": line_number,
                              "offset": offset,
                              "message": text[5:],
-                             "source": self.lines[line_number],
+                             "source": self.lines[line_number - 1],
                              })
 
         self.file_errors += 1

--- a/testsuite/test_all.py
+++ b/testsuite/test_all.py
@@ -46,6 +46,15 @@ class PycodestyleTestCase(unittest.TestCase):
         self.assertEqual(list(report.messages.keys()), ['W504'],
                          msg='Failures: %s' % report.messages)
 
+    def test_list_reporter(self):
+        files = [pycodestyle.__file__.rstrip('oc'), __file__.rstrip('oc'),
+                 os.path.join(ROOT_DIR, 'setup.py')]
+        report = self._style.init_report(pycodestyle.ListReport)
+        report = self._style.check_files(files)
+        self.assertTrue(len(report.entries) > 0)
+        self.assertIsInstance(report.entries[0], dict)
+        self.assertEqual(report.entries[0]["message_code"], 'W504')
+
 
 def suite():
     from testsuite import (


### PR DESCRIPTION
Allow users to easily access structured output from `Checker` directly by providing a simple Report class with a list of dictionaries.

See example below:
```
>>> report = pycodestyle.ListReport(options=style_guide.options)
>>> checker = pycodestyle.Checker(lines=lines, report=report)
>>> checker.check_all()
>>> print(report.entries)
[{'message_class': 'error',
   'message_code': 'W292',
   'filename': 'stdin',
   'lineno': 1,
   'offset': 57,
   'message': 'no newline at end of file',
   'source': 'from .client import Client, ResultError, JobNotFoundError'},
  {'message_class': 'error',
   'message_code': 'E501',
   'filename': 'stdin',
   'lineno': 177,
   'offset': 79,
   'message': 'line too long (105 > 79 characters)',
   'source': '        # we can terminate quickly by checking if the process is not running and it has no queued output.'},
  {'message_class': 'error',
   'message_code': 'E122',
   'filename': 'stdin',
   'lineno': 2,
   'offset': 0,
   'message': 'continuation line missing indentation or outdented',
   'source': 'import uuid'},
...
```

See also discussion at: https://github.com/PyCQA/pyflakes/pull/462
