### PR TITLE
Support visual indent of continuation lines after with/assert/raise.

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -695,6 +695,9 @@ def continued_indentation(logical_line, tokens, indent_level, hang_closing,
         elif (token_type in (tokenize.STRING, tokenize.COMMENT) or
               text in ('u', 'ur', 'b', 'br')):
             indent_chances[start[1]] = str
+        # visual indent after assert/raise/with
+        elif not row and not depth and text in ["assert", "raise", "with"]:
+            indent_chances[end[1] + 1] = True
         # special case for the "if" statement because len("if (") == 4
         elif not indent_chances and not row and not depth and text == 'if':
             indent_chances[end[1] + 1] = True

--- a/testsuite/E12.py
+++ b/testsuite/E12.py
@@ -372,4 +372,26 @@ print(True)
 
 print(a
 , end=' ')
-#:
+#: E127:4:12
+def foo():
+    pass
+    raise 123 + \
+           123
+#: E127:4:13
+class Eggs:
+    pass
+    assert 123456 == \
+            123456
+#: E127:4:11
+def f1():
+    print('foo')
+    with open('/path/to/some/file/you/want/to/read') as file_1, \
+          open('/path/to/some/file/being/written', 'w') as file_2:
+        file_2.write(file_1.read())
+#: E127:5:11
+def f1():
+    print('foo')
+    with open('/path/to/some/file/you/want/to/read') as file_1, \
+         open('/path/to/some/file/being/written', 'w') as file_2, \
+          open('later-misindent'):
+        file_2.write(file_1.read())

--- a/testsuite/E12not.py
+++ b/testsuite/E12not.py
@@ -639,3 +639,23 @@ print dedent(
         # more stuff
     )
 )
+
+
+def foo():
+    pass
+    raise 123 + \
+          123
+
+
+class Eggs:
+    pass
+    assert 123456 == \
+           123456
+
+
+def f1():
+    print('foo')
+    with open('/path/to/some/file/you/want/to/read') as file_1, \
+         open('/path/to/some/file/being/written', 'w') as file_2, \
+         open('just-making-sure-more-continuations-also-work'):
+        file_2.write(file_1.read())


### PR DESCRIPTION
"with" is likely the most common case, and this indentation is
explicitly given as example by PEP8 (under "maximum line length").

Closes #569.