### PR TITLE
Correctly allow *two* blank lines after a block of one-liners.

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1794,6 +1794,7 @@ def expand_indent(line):
     >>> expand_indent('        \t')
     16
     """
+    line = line.rstrip('\n\r')
     if '\t' not in line:
         return len(line) - len(line.lstrip())
     result = 0

--- a/testsuite/E30not.py
+++ b/testsuite/E30not.py
@@ -167,6 +167,10 @@ def foo(x):
 # for no E30x being emitted.
 def bar(): pass
 def baz(): pass
+
+
+def main():
+    pass
 #: E704:4:5 E704:5:5
 def foo():
     # This emits the (ignored-by-default) E704, but here we're testing


### PR DESCRIPTION
Previously
```
def oneliner(): pass
def otheroneliner(): pass

def really_long_func():
    with_some_contents
```
would raise an "E302: expected 2 blank lines, found zero" at the last
line of the one liner.  Ultimately, this is due to `expand_indent` being
passed a line whose contents are just a newline and nothing else, and
`expand_indent` thinking that the line is indented by 1 character (the
newline), which is wrong.

Fix that by just stripping the newline, and modify a test to cover this
case.