### PR TITLE
Fix false alarm in E203 rule (issue #373, black incompatibility)

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -413,6 +413,12 @@ def extraneous_whitespace(logical_line):
     - Immediately inside parentheses, brackets or braces.
     - Immediately before a comma, semicolon, or colon.
 
+    Exceptions:
+    - When the colon acts as a slice, the rule of binary operators
+      applies and we should have the same amount of space on either side
+    - When the colon acts as a slice but a parameter is omitted, then
+      the space is omitted
+
     Okay: spam(ham[1], {eggs: 2})
     E201: spam( ham[1], {eggs: 2})
     E201: spam(ham[ 1], {eggs: 2})
@@ -421,10 +427,32 @@ def extraneous_whitespace(logical_line):
     E202: spam(ham[1 ], {eggs: 2})
     E202: spam(ham[1], {eggs: 2 })
 
+    Okay: ham[8 : 2]
+    Okay: ham[: 2]
     E203: if x == 4: print x, y; x, y = y , x
     E203: if x == 4: print x, y ; x, y = y, x
     E203: if x == 4 : print x, y; x, y = y, x
     """
+
+    def is_a_slice(line, colon_position):
+        """Check colon acts as a slice
+
+        Return True if the colon is directly contained within
+        square brackets.
+        """
+        parentheses_brackets_braces = list()
+        for i in range(colon_position):
+            c = line[i]
+            if c in '[({':
+                parentheses_brackets_braces += c
+            elif c in '])}':
+                last_opened = parentheses_brackets_braces.pop()
+                expected_close = {'{': '}', '(': ')', '[': ']'}[last_opened]
+                if c != expected_close:  # invalid Python code
+                    return False
+        return (len(parentheses_brackets_braces) > 0 and
+                parentheses_brackets_braces.pop() == '[')
+
     line = logical_line
     for match in EXTRANEOUS_WHITESPACE_REGEX.finditer(line):
         text = match.group()
@@ -433,7 +461,8 @@ def extraneous_whitespace(logical_line):
         if text == char + ' ':
             # assert char in '([{'
             yield found + 1, "E201 whitespace after '%s'" % char
-        elif line[found - 1] != ',':
+        elif (line[found - 1] != ',' and
+              not (char == ':' and is_a_slice(line, found))):
             code = ('E202' if char in '}])' else 'E203')  # if char in ',;:'
             yield found, "%s whitespace before '%s'" % (code, char)
 

--- a/testsuite/E20.py
+++ b/testsuite/E20.py
@@ -46,10 +46,16 @@ if x == 4:
 if x == 4:
     print x, y
     x, y = y , x
+#: E203:1:37
+foo[idxs[2 : 6] : spam(ham[1], {eggs : a[2 : 4]})]
 #: Okay
 if x == 4:
     print x, y
     x, y = y, x
 a[b1, :] == a[b1, ...]
 b = a[:, b1]
+ham[1:9], ham[1:9:3], ham[:9:3], ham[1::3], ham[1:9:]
+ham[: upper_fn(x) : step_fn(x)], ham[:: step_fn(x)]
+ham[lower + offset : upper + offset]
+foo[idxs[2 : 6] : spam(ham[1], {eggs: a[2 : 4]})]
 #:


### PR DESCRIPTION
## Issue #373

Rule E203 checks for extraneous whitespace before a colon.
Yet there is a corner case when the colon is used as a "slice" operator. [PEP8](https://www.python.org/dev/peps/pep-0008/#pet-peeves) says:

> However, in a slice the colon acts like a binary operator, and should have equal amounts on either side (treating it as the operator with the lowest priority). In an extended slice, both colons must have the same amount of spacing applied.

This behaviour isn't implemented and leads to conflict between pycodestyle and [black](https://github.com/psf/black).

## Solution

This PR adds to pycodestyle the tolerance for the slice situation, **without** enforcing the "same amount of space on both sides of the colon" rule.
This way the current Python that code was pycodestyle compliant stays compliant.

## Performance

On a Python code base of over 15k lines, a test with [hyperfine](https://github.com/sharkdp/hyperfine) shows no performance loss.