### PR TITLE
Update documentation URLs to pycodestyle.pycqa.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,7 +6,7 @@ pycodestyle (formerly called pep8) - Python style guide checker
    :alt: Build status
 
 .. image:: https://readthedocs.org/projects/pycodestyle/badge/?version=latest
-    :target: https://pycodestyle.readthedocs.io
+    :target: https://pycodestyle.pycqa.org
     :alt: Documentation Status
 
 .. image:: https://img.shields.io/pypi/wheel/pycodestyle.svg
@@ -103,6 +103,6 @@ Or you can display how often each error was found::
 Links
 -----
 
-* `Read the documentation <https://pycodestyle.readthedocs.io/>`_
+* `Read the documentation <https://pycodestyle.pycqa.org/>`_
 
 * `Fork me on GitHub <http://github.com/PyCQA/pycodestyle>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,7 +21,7 @@ Contents:
    API <api>
    developer
 
-* Online documentation: https://pycodestyle.readthedocs.io/
+* Online documentation: https://pycodestyle.pycqa.org/
 * Source code and issue tracker: https://github.com/pycqa/pycodestyle
 
 

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setup(
     author_email='johann@rocholl.net',
     maintainer='Ian Lee',
     maintainer_email='IanLee1521@gmail.com',
-    url='https://pycodestyle.readthedocs.io/',
+    url='https://pycodestyle.pycqa.org/',
     license='Expat license',
     py_modules=['pycodestyle'],
     namespace_packages=[],


### PR DESCRIPTION
The project documentation seems to have changed location. There were still a few URLs pointing to the old one.