### PR TITLE
recognize cimport as a valid import statement

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1135,7 +1135,8 @@ def module_imports_on_top_of_file(
     if noqa:
         return
     line = logical_line
-    if line.startswith('import ') or line.startswith('from '):
+    if (line.startswith('import ') or line.startswith('from ') or
+            line.startswith('cimport ')):
         if checker_state.get('seen_non_imports', False):
             yield 0, "E402 module level import not at top of file"
     elif re.match(DUNDER_REGEX, line):

--- a/testsuite/E40.py
+++ b/testsuite/E40.py
@@ -48,6 +48,10 @@ elif not True:
 else:
     import mwahaha
 
+import foo
+#: Okay
+cimport bar
+
 import bar
 #: E402
 VERSION = '1.2.3'


### PR DESCRIPTION
`cimport` is used by Cython to import other modules. This PR adds support to recognize it so not to generate E402 errors when `cimport` is used.