### PR TITLE
Add lines as arg to ast checks

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -2114,7 +2114,10 @@ class Checker(object):
         except (ValueError, SyntaxError, TypeError):
             return self.report_invalid_syntax()
         for name, cls, __ in self._ast_checks:
-            checker = cls(tree, self.filename)
+            if len(_get_parameters(cls.__init__)) == 2:
+                checker = cls(tree, self.filename)
+            elif len(_get_parameters(cls.__init__)) == 3:
+                checker = cls(tree, self.filename, self.lines)
             for lineno, offset, text, check in checker.run():
                 if not self.lines or not noqa(self.lines[lineno - 1]):
                     self.report_error(lineno, offset, text, check)


### PR DESCRIPTION
Adding lines as an argument to the ast checks besides tree and filename, to allow manually parsing of the contents of the file