### PR TITLE
Add lines arg to ast checks

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -2114,13 +2114,15 @@ class Checker(object):
         except (ValueError, SyntaxError, TypeError):
             return self.report_invalid_syntax()
         for name, cls, __ in self._ast_checks:
+            checker = None
             if len(_get_parameters(cls.__init__)) == 2:
                 checker = cls(tree, self.filename)
             elif len(_get_parameters(cls.__init__)) == 3:
                 checker = cls(tree, self.filename, self.lines)
-            for lineno, offset, text, check in checker.run():
-                if not self.lines or not noqa(self.lines[lineno - 1]):
-                    self.report_error(lineno, offset, text, check)
+            if checker != None:
+                for lineno, offset, text, check in checker.run():
+                    if not self.lines or not noqa(self.lines[lineno - 1]):
+                        self.report_error(lineno, offset, text, check)
 
     def generate_tokens(self):
         """Tokenize file, run physical line checks and yield tokens."""

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -2114,7 +2114,10 @@ class Checker(object):
         except (ValueError, SyntaxError, TypeError):
             return self.report_invalid_syntax()
         for name, cls, __ in self._ast_checks:
-            checker = cls(tree, self.filename)
+            if len(_get_parameters(cls.__init__)) == 2:
+                checker = cls(tree, self.filename)
+            elif len(_get_parameters(cls.__init__)) == 3:
+                checker = cls(tree, self.filename, self.lines)
             for lineno, offset, text, check in checker.run():
                 if not self.lines or not noqa(self.lines[lineno - 1]):
                     self.report_error(lineno, offset, text, check)

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -2119,10 +2119,9 @@ class Checker(object):
                 checker = cls(tree, self.filename)
             elif len(_get_parameters(cls.__init__)) == 3:
                 checker = cls(tree, self.filename, self.lines)
-            if checker != None:
-                for lineno, offset, text, check in checker.run():
-                    if not self.lines or not noqa(self.lines[lineno - 1]):
-                        self.report_error(lineno, offset, text, check)
+            for lineno, offset, text, check in checker.run():
+                if not self.lines or not noqa(self.lines[lineno - 1]):
+                    self.report_error(lineno, offset, text, check)
 
     def generate_tokens(self):
         """Tokenize file, run physical line checks and yield tokens."""

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -2115,9 +2115,9 @@ class Checker(object):
             return self.report_invalid_syntax()
         for name, cls, __ in self._ast_checks:
             checker = None
-            if len(_get_parameters(cls.__init__)) == 2:
+            if len(_get_parameters(cls.__init__)) == 3:
                 checker = cls(tree, self.filename)
-            elif len(_get_parameters(cls.__init__)) == 3:
+            elif len(_get_parameters(cls.__init__)) == 4:
                 checker = cls(tree, self.filename, self.lines)
             for lineno, offset, text, check in checker.run():
                 if not self.lines or not noqa(self.lines[lineno - 1]):


### PR DESCRIPTION
When using AST for finding a specific Call, yielding the AST node's lineno and offset will mark the initial row if it's a multiline statement. If the multiline has many lines it becomes hard to pinpoint the exact place where the offending Call is. To solve this, it's necessary to add a physical parsing of the lines that form the multiline statement. For this, the lines of the source code need to be given as an argument.