### PR TITLE
E704: Ignore def with "..." as its body as stub / @typing.overload

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1205,7 +1205,8 @@ def compound_statements(logical_line):
                               "def")
                 break
             if STARTSWITH_DEF_REGEX.match(line):
-                yield 0, "E704 multiple statements on one line (def)"
+                if line[found + 1:].strip() != '...':  # stub / typing overload
+                    yield 0, "E704 multiple statements on one line (def)"
             elif STARTSWITH_INDENT_STATEMENT_REGEX.match(line):
                 yield found, "E701 multiple statements on one line (colon)"
         prev_found = found

--- a/testsuite/E30not.py
+++ b/testsuite/E30not.py
@@ -177,13 +177,11 @@ def foo():
     # for no E30x being emitted.
     def bar(): pass
     def baz(): pass
-#: E704:8:1 E704:10:1
+#: Okay
 from typing import overload
 from typing import Union
 
 
-# This emits the (ignored-by-default) E704, but here we're testing
-# for no E30x being emitted.
 @overload
 def f(x: int) -> int: ...
 @overload
@@ -192,13 +190,11 @@ def f(x: str) -> str: ...
 
 def f(x: Union[int, str]) -> Union[int, str]:
     return x
-#: E704:8:5 E704:10:5
+#: Okay
 from typing import Protocol
 
 
 class C(Protocol):
-    # This emits the (ignored-by-default) E704, but here we're testing
-    # for no E30x being emitted.
     @property
     def f(self) -> int: ...
     @property


### PR DESCRIPTION
Handle a common pattern used by Python's `@typing.overload`