### PR TITLE
introduce root argument

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -149,6 +149,8 @@ Quick help is available on the command line::
                          separated patterns (default: .svn,CVS,.bzr,.hg,.git)
     --filename=patterns  when parsing directories, only check filenames matching
                          these comma separated patterns (default: *.py)
+    --root=dir           when looking for project options, only check the
+                         directory provided (ignored if not set)
     --select=errors      select errors and warnings (e.g. E,W6)
     --ignore=errors      skip errors and warnings (e.g. E4,W)
     --show-source        show source code for each error

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1900,6 +1900,20 @@ def parse_udiff(diff, patterns=None, parent='.'):
     }
 
 
+def normalize_path(value, parent=os.curdir):
+    """Normalize a provided path.
+
+    Return an absolute path or `None` if no path was provided.
+    """
+    if not value:
+        return None
+
+    path = value.strip()
+    if '/' in path:
+        path = os.path.abspath(os.path.join(parent, path))
+    return path.rstrip('/')
+
+
 def normalize_paths(value, parent=os.curdir):
     """Parse a comma-separated list of paths.
 
@@ -1911,10 +1925,7 @@ def normalize_paths(value, parent=os.curdir):
         return value
     paths = []
     for path in value.split(','):
-        path = path.strip()
-        if '/' in path:
-            path = os.path.abspath(os.path.join(parent, path))
-        paths.append(path.rstrip('/'))
+        paths.append(normalize_path(path, parent=parent))
     return paths
 
 

--- a/testsuite/test_shell.py
+++ b/testsuite/test_shell.py
@@ -84,6 +84,13 @@ class ShellTestCase(unittest.TestCase):
             self.assertEqual(x, str(num))
             self.assertEqual(y, str(col))
             self.assertTrue(msg.startswith(' E11'))
+
+    def test_check_config(self):
+        stdout, stderr, errcode = self.pycodestyle('-')
+        self.assertFalse(errcode)
+        self.assertFalse(stderr)
+        self.assertFalse(stdout)
+
         # Config file read from the pycodestyle's setup.cfg
         config_filenames = [os.path.basename(p)
                             for p in self._config_filenames]

--- a/testsuite/test_shell.py
+++ b/testsuite/test_shell.py
@@ -96,6 +96,30 @@ class ShellTestCase(unittest.TestCase):
                             for p in self._config_filenames]
         self.assertTrue('setup.cfg' in config_filenames)
 
+    def test_check_config_root_none(self):
+        root_dir = 'testsuite'
+        stdout, stderr, errcode = self.pycodestyle('--root', root_dir, '-')
+        self.assertFalse(errcode)
+        self.assertFalse(stderr)
+        self.assertFalse(stdout)
+
+        # No configuration file should exist in `testsuite`
+        config_filenames = [os.path.basename(p)
+                            for p in self._config_filenames]
+        self.assertFalse(config_filenames)
+
+    def test_check_config_root_toxini(self):
+        root_dir = 'testsuite/example-tox-ini'
+        stdout, stderr, errcode = self.pycodestyle('--root', root_dir, '-')
+        self.assertFalse(errcode)
+        self.assertFalse(stderr)
+        self.assertFalse(stdout)
+
+        # Config file read from example tox.ini
+        config_filenames = [os.path.basename(p)
+                            for p in self._config_filenames]
+        self.assertTrue('tox.ini' in config_filenames)
+
     def test_check_stdin(self):
         pycodestyle.PROJECT_CONFIG = ()
         stdout, stderr, errcode = self.pycodestyle('-')

--- a/testsuite/test_util.py
+++ b/testsuite/test_util.py
@@ -3,10 +3,22 @@
 import os
 import unittest
 
+from pycodestyle import normalize_path
 from pycodestyle import normalize_paths
 
 
 class UtilTestCase(unittest.TestCase):
+    def test_normalize_path(self):
+        cwd = os.getcwd()
+
+        self.assertEqual(normalize_path(''), None)
+        self.assertEqual(normalize_path(None), None)
+        self.assertEqual(normalize_path('foo'), 'foo')
+        self.assertEqual(normalize_path('  bar  '), 'bar')
+        self.assertEqual(normalize_path('/foo/bar'), '/foo/bar')
+        self.assertEqual(normalize_path('baz/../bat'), cwd + '/bat')
+        self.assertEqual(normalize_path("\n   build/*"), cwd + '/build/*')
+
     def test_normalize_paths(self):
         cwd = os.getcwd()
 


### PR DESCRIPTION
The following commit introduces a new argument `--root`, which allows a caller to specify the base location where a project-specific configuration can be found. This is primarily to enable callers which feed data through `stdin` to specify a possible project configuration without explicitly configuring the working directory when pycodestyle is invoked.