### PR TITLE
Windows path issues

### DIFF
--- a/testsuite/test_shell.py
+++ b/testsuite/test_shell.py
@@ -79,7 +79,7 @@ class ShellTestCase(unittest.TestCase):
         self.assertFalse(stderr)
         self.assertEqual(len(stdout), 24)
         for line, num, col in zip(stdout, (3, 6, 6, 9, 12), (3, 6, 6, 1, 5)):
-            path, x, y, msg = line.split(':')
+            path, x, y, msg = line.rsplit(':', 3)
             self.assertTrue(path.endswith(E11))
             self.assertEqual(x, str(num))
             self.assertEqual(y, str(col))

--- a/testsuite/test_util.py
+++ b/testsuite/test_util.py
@@ -18,6 +18,6 @@ class UtilTestCase(unittest.TestCase):
         self.assertEqual(normalize_paths('foo,bar'), ['foo', 'bar'])
         self.assertEqual(normalize_paths('foo,  bar  '), ['foo', 'bar'])
         self.assertEqual(normalize_paths('/foo/bar,baz/../bat'),
-                         ['/foo/bar', cwd + '/bat'])
+                         [os.path.realpath('/foo/bar'), cwd + '/bat'])
         self.assertEqual(normalize_paths(".pyc,\n   build/*"),
                          ['.pyc', cwd + '/build/*'])


### PR DESCRIPTION
Fix tests to handle paths in Windows.  NormalizePath works properly but the tests would still fail because NormalizePath would NOT work as the test results expected.  Verified on Windows with command:  `/mingw64/bin/python -m unittest discover testsuite -v`

Results:
`D:\msys64\home\jpmugaas\pycodestyle/pycodestyle.py:124:30: W504 line break after binary operator
D:\msys64\home\jpmugaas\pycodestyle/pycodestyle.py:125:35: W504 line break after binary operator
D:\msys64\home\jpmugaas\pycodestyle/pycodestyle.py:298:46: W504 line break after binary operator
D:\msys64\home\jpmugaas\pycodestyle/pycodestyle.py:394:41: W504 line break after binary operator
D:\msys64\home\jpmugaas\pycodestyle/pycodestyle.py:401:75: W504ok
test_selftest (test_all.PycodestyleTestCase) ... ok
test_check_nullbytes (test_api.APITestCase) ... ok
test_check_unicode (test_api.APITestCase) ... ok
test_register_ast_check (test_api.APITestCase) ... ok
test_register_invalid_check (test_api.APITestCase) ... ok
test_register_logical_check (test_api.APITestCase) ... ok
test_register_physical_check (test_api.APITestCase) ... ok
test_styleguide (test_api.APITestCase) ... ok
test_styleguide_check_files (test_api.APITestCase) ... ok
test_styleguide_checks (test_api.APITestCase) ... ok
test_styleguide_continuation_line_outdented (test_api.APITestCase) ... ok
test_styleguide_excluded (test_api.APITestCase) ... ok
test_styleguide_ignore_code (test_api.APITestCase) ... ok
test_styleguide_init_report (test_api.APITestCase) ... ok
test_styleguide_options (test_api.APITestCase) ... ok
test_styleguide_unmatched_triple_quotes (test_api.APITestCase) ... ok
test_blank_line_between_decorator (test_blank_lines.TestBlankLinesDefault)
It will trigger an error when the decorator is followed by a ... ok
test_blank_line_decorator (test_blank_lines.TestBlankLinesDefault)
It will accept the decorators which are adjacent to the function ... ok
test_initial_lines_more_blank (test_blank_lines.TestBlankLinesDefault)
It will trigger an error for more than 2 blank lines before the ... ok
test_initial_lines_one_blank (test_blank_lines.TestBlankLinesDefault)
It will accept 1 blank lines before the first line of actual ... ok
test_initial_lines_two_blanks (test_blank_lines.TestBlankLinesDefault)
It will accept 2 blank lines before the first line of actual ... ok
test_initial_no_blank (test_blank_lines.TestBlankLinesDefault)
It will accept no blank lines at the start of the file. ... ok
test_method_fewer_follow_lines (test_blank_lines.TestBlankLinesDefault)
It will trigger an error when less than 1 blank line is ... ok
test_method_less_blank_lines (test_blank_lines.TestBlankLinesDefault)
It will trigger an error when less than 1 blank lin is found ... ok
test_method_less_blank_lines_comment (test_blank_lines.TestBlankLinesDefault)
It will trigger an error when less than 1 blank lin is found ... ok
test_method_more_blank_lines (test_blank_lines.TestBlankLinesDefault)
It will trigger an error when more than 1 blank line is found ... ok
test_method_nested_fewer_follow_lines (test_blank_lines.TestBlankLinesDefault)
It will trigger an error when less than 1 blank line is ... ok
test_method_nested_less_class (test_blank_lines.TestBlankLinesDefault)
It will trigger an error when less than 1 blank line is found ... ok
test_method_nested_ok (test_blank_lines.TestBlankLinesDefault)
Will not trigger an error when 1 blank line is found ... ok
test_top_level_fewer_blank_lines (test_blank_lines.TestBlankLinesDefault)
It will trigger an error when less 2 blank lines are found ... ok
test_top_level_fewer_follow_lines (test_blank_lines.TestBlankLinesDefault)
It will trigger an error when less than 2 blank lines are ... ok
test_top_level_fewer_follow_lines_comments (test_blank_lines.TestBlankLinesDefault)
It will trigger an error when less than 2 blank lines are ... ok
test_top_level_good_follow_lines (test_blank_lines.TestBlankLinesDefault)
It not trigger an error when 2 blank lines are ... ok
test_top_level_more_blank_lines (test_blank_lines.TestBlankLinesDefault)
It will trigger an error when more 2 blank lines are found ... ok
test_initial_lines_one_blanks (test_blank_lines.TestBlankLinesTwisted)
It will accept less than 3 blank lines before the first line of ... ok
test_initial_lines_tree_blanks (test_blank_lines.TestBlankLinesTwisted)
It will accept 3 blank lines before the first line of actual ... ok
test_the_right_blanks (test_blank_lines.TestBlankLinesTwisted)
It will accept 3 blank for top level and 2 for nested. ... ok
test_top_level_fewer_blank_lines (test_blank_lines.TestBlankLinesTwisted)
It will trigger an error when less 3 blank lines are found ... ok
test_top_level_more_blank_lines (test_blank_lines.TestBlankLinesTwisted)
It will trigger an error when more 2 blank lines are found ... ok
test_multiline_ignore_parsing (test_parser.ParserTestCase) ... ok
test_multiline_trailing_comma_ignore_parsing (test_parser.ParserTestCase) ... ok
test_trailing_comma_ignore_parsing (test_parser.ParserTestCase) ... ok
test_vanilla_ignore_parsing (test_parser.ParserTestCase) ... ok
test_check_diff (test_shell.ShellTestCase) ... ok
test_check_noarg (test_shell.ShellTestCase) ... ok
test_check_non_existent (test_shell.ShellTestCase) ... ok
test_check_simple (test_shell.ShellTestCase) ... ok
test_check_stdin (test_shell.ShellTestCase) ... ok
test_print_usage (test_shell.ShellTestCase) ... ok
test_normalize_paths (test_util.UtilTestCase) ... ok

----------------------------------------------------------------------
Ran 53 tests in 1.255s

OK`