### PR TITLE
Re-consider providing pre-commit hook metadata

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,6 @@
+-   id: pycodestyle
+    name: pycodetyle
+    description: pycodestyle is a tool to check your Python code against some of the style conventions in PEP 8.
+    entry: pycodestyle
+    language: python
+    types: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
--   id: pycodestyle
-    name: pycodetyle
-    description: pycodestyle is a tool to check your Python code against some of the style conventions in PEP 8.
-    entry: pycodestyle
-    language: python
-    types: [python]
+- id: pycodestyle
+  name: pycodetyle
+  description: pycodestyle is a tool to check your Python code against some of the style conventions in PEP 8.
+  entry: pycodestyle
+  language: python
+  types: [python]

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,5 +1,5 @@
 - id: pycodestyle
-  name: pycodetyle
+  name: pycodestyle
   description: pycodestyle is a tool to check your Python code against some of the style conventions in PEP 8.
   entry: pycodestyle
   language: python


### PR DESCRIPTION
I am opening this pull request for your re-consideration of PR #821.  I understand the reason for closing #821, but I don't use flake8 and I do use pycodestyle; perhaps I'm the only one in this situation (and need to re-consider using flake8).

My workflow is:

1. Run QA tools in my IDE on the file currently being edited.
2. Run QA tools across the group of files included in a commit using pre-commit hooks.
3. Run QA tools across the entire code base as a GitHub action on each pull-request/push.

Thus, step 2 requires a pycodestyle pre-commit hook.

Following the contributing guidelines, I've toxed my fork and all tests pass, although that's probably moot given the proposed change.  However, I've been using the following in my .pre-commit-config.yaml for the past three weeks with no problems.

```
- repo: https://github.com/weibullguy/pycodestyle
  rev: '2.6.1'
  hooks:
    - id: pycodestyle
      args: [--config, ./setup.cfg]
```