### PR TITLE
Fix false-positive E211 with match and case

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,9 @@ jobs:
           py: 3.9
           toxenv: py
         - os: ubuntu-latest
+          py: 3.10-dev
+          toxenv: py
+        - os: ubuntu-latest
           py: 3.9
           toxenv: flake8
     runs-on: ${{ matrix.os }}

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -821,7 +821,10 @@ def whitespace_before_parameters(logical_line, tokens):
             # Allow "return (a.foo for a in range(5))"
             not keyword.iskeyword(prev_text) and
             # 'match' and 'case' are only soft keywords
-            prev_text not in ('match', 'case')
+            (
+                sys.version_info <= (3, 10) or
+                not keyword.issoftkeyword(prev_text)
+            )
         ):
             yield prev_end, "E211 whitespace before '%s'" % text
         prev_type = token_type

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -811,14 +811,18 @@ def whitespace_before_parameters(logical_line, tokens):
     prev_type, prev_text, __, prev_end, __ = tokens[0]
     for index in range(1, len(tokens)):
         token_type, text, start, end, __ = tokens[index]
-        if (token_type == tokenize.OP and
+        if (
+            token_type == tokenize.OP and
             text in '([' and
             start != prev_end and
             (prev_type == tokenize.NAME or prev_text in '}])') and
             # Syntax "class A (B):" is allowed, but avoid it
             (index < 2 or tokens[index - 2][1] != 'class') and
-                # Allow "return (a.foo for a in range(5))"
-                not keyword.iskeyword(prev_text)):
+            # Allow "return (a.foo for a in range(5))"
+            not keyword.iskeyword(prev_text) and
+            # 'match' and 'case' are only soft keywords
+            prev_text not in ('match', 'case')
+        ):
             yield prev_end, "E211 whitespace before '%s'" % text
         prev_type = token_type
         prev_text = text

--- a/testsuite/python310.py
+++ b/testsuite/python310.py
@@ -1,0 +1,12 @@
+var, var2 = 1, 2
+#: Okay
+match (var, var2):
+    #: Okay
+    case [2, 3]:
+        pass
+    #: Okay
+    case (1, 2):
+        pass
+    #: Okay
+    case _:
+        print("Default")

--- a/testsuite/python310.py
+++ b/testsuite/python310.py
@@ -1,12 +1,9 @@
-var, var2 = 1, 2
 #: Okay
+var, var2 = 1, 2
 match (var, var2):
-    #: Okay
     case [2, 3]:
         pass
-    #: Okay
     case (1, 2):
         pass
-    #: Okay
     case _:
         print("Default")

--- a/testsuite/support.py
+++ b/testsuite/support.py
@@ -169,7 +169,7 @@ def init_tests(pep8style):
     def run_tests(filename):
         """Run all the tests from a file."""
         # Skip tests meant for higher versions of python
-        ver_match = re.search(r'python(\d)(\d)?\.py$', filename)
+        ver_match = re.search(r'python(\d)(\d+)?\.py$', filename)
         if ver_match:
             test_against_version = tuple(int(val or 0)
                                          for val in ver_match.groups())


### PR DESCRIPTION
Fix false-positive `E211 whitespace before '('` for `match` and `case`, Python 3.10