### PR TITLE
Add whitespace checks for ``match`` and ``case``

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -494,6 +494,17 @@ def whitespace_around_keywords(logical_line):
         elif len(after) > 1:
             yield match.start(2), "E271 multiple spaces after keyword"
 
+    if sys.version_info >= (3, 10):
+        match = MATCH_CASE_REGEX.match(logical_line)
+        if match:
+            whitespace = match.groups()[0]
+            if whitespace == ' ':
+                return
+            if whitespace == '':
+                yield match.start(1), "E275 missing whitespace after keyword"
+            else:
+                yield match.start(1), "E271 multiple spaces after keyword"
+
 
 @register_check
 def missing_whitespace_after_import_keyword(logical_line):
@@ -511,32 +522,6 @@ def missing_whitespace_after_import_keyword(logical_line):
         if -1 < found:
             pos = found + len(indicator) - 1
             yield pos, "E275 missing whitespace after keyword"
-
-
-@register_check
-def missing_whitespace_after_match_case(logical_line):
-    r"""Check whitespace after 'match' and 'case'.
-
-    Python 3.10
-    Okay: match status:
-    E271: match  status:
-    E271: case\tstatus:
-    E271: case   _:
-    E275: matchstatus:
-    E275: casestatus:
-    E275: case_:
-    """
-    if sys.version_info < (3, 10):
-        return
-    match = MATCH_CASE_REGEX.match(logical_line)
-    if match:
-        whitespace = match.groups()[0]
-        if whitespace == ' ':
-            return
-        if whitespace == '':
-            yield match.start(1), "E275 missing whitespace after keyword"
-        else:
-            yield match.start(1), "E271 multiple spaces after keyword"
 
 
 @register_check

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -497,10 +497,9 @@ def whitespace_around_keywords(logical_line):
     if sys.version_info >= (3, 10):
         match = MATCH_CASE_REGEX.match(logical_line)
         if match:
-            whitespace = match.groups()[0]
-            if whitespace == ' ':
+            if match[1] == ' ':
                 return
-            if whitespace == '':
+            if match[1] == '':
                 yield match.start(1), "E275 missing whitespace after keyword"
             else:
                 yield match.start(1), "E271 multiple spaces after keyword"

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -163,6 +163,7 @@ STARTSWITH_INDENT_STATEMENT_REGEX = re.compile(
     )))
 )
 DUNDER_REGEX = re.compile(r'^__([^\s]+)__ = ')
+MATCH_CASE_REGEX = re.compile(r'^\s*\b(?:match|case)(\s*)(?=.*\:)')
 
 _checks = {'physical_line': {}, 'logical_line': {}, 'tree': {}}
 
@@ -510,6 +511,32 @@ def missing_whitespace_after_import_keyword(logical_line):
         if -1 < found:
             pos = found + len(indicator) - 1
             yield pos, "E275 missing whitespace after keyword"
+
+
+@register_check
+def missing_whitespace_after_match_case(logical_line):
+    r"""Check whitespace after 'match' and 'case'.
+
+    Python 3.10
+    Okay: match status:
+    E271: match  status:
+    E271: case\tstatus:
+    E271: case   _:
+    E275: matchstatus:
+    E275: casestatus:
+    E275: case_:
+    """
+    if sys.version_info < (3, 10):
+        return
+    match = MATCH_CASE_REGEX.match(logical_line)
+    if match:
+        whitespace = match.groups()[0]
+        if whitespace == ' ':
+            return
+        if whitespace == '':
+            yield match.start(1), "E275 missing whitespace after keyword"
+        else:
+            yield match.start(1), "E271 multiple spaces after keyword"
 
 
 @register_check

--- a/testsuite/python310.py
+++ b/testsuite/python310.py
@@ -7,3 +7,21 @@ match (var, var2):
         pass
     case _:
         print("Default")
+#: E271:2:6 E271:3:9 E271:5:9 E271:7:9
+var = 1
+match  var:
+    case  1:
+        pass
+    case	2:
+        pass
+    case  (
+        3
+    ):
+        pass
+#: E275:2:6 E275:3:9 E275:5:9
+var = 1
+match(var):
+    case(1):
+        pass
+    case_:
+        pass

--- a/testsuite/support.py
+++ b/testsuite/support.py
@@ -6,7 +6,6 @@ import sys
 from pycodestyle import Checker, BaseReport, StandardReport, readlines
 
 SELFTEST_REGEX = re.compile(r'\b(Okay|[EW]\d{3}):\s(.*)')
-SELFTEST_PY_REGEX = re.compile(r'\bPython (\d).(\d+)')
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 
 
@@ -113,14 +112,8 @@ def selftest(options):
     counters = report.counters
     checks = options.physical_checks + options.logical_checks
     for name, check, argument_names in checks:
-        python_version = None
         for line in check.__doc__.splitlines():
             line = line.lstrip()
-            match = SELFTEST_PY_REGEX.match(line)
-            if match:
-                python_version = tuple(map(int, match.groups()))
-            if python_version and sys.version_info < python_version:
-                continue
             match = SELFTEST_REGEX.match(line)
             if match is None:
                 continue

--- a/testsuite/support.py
+++ b/testsuite/support.py
@@ -6,6 +6,7 @@ import sys
 from pycodestyle import Checker, BaseReport, StandardReport, readlines
 
 SELFTEST_REGEX = re.compile(r'\b(Okay|[EW]\d{3}):\s(.*)')
+SELFTEST_PY_REGEX = re.compile(r'\bPython (\d).(\d+)')
 ROOT_DIR = os.path.dirname(os.path.dirname(__file__))
 
 
@@ -112,8 +113,14 @@ def selftest(options):
     counters = report.counters
     checks = options.physical_checks + options.logical_checks
     for name, check, argument_names in checks:
+        python_version = None
         for line in check.__doc__.splitlines():
             line = line.lstrip()
+            match = SELFTEST_PY_REGEX.match(line)
+            if match:
+                python_version = tuple(map(int, match.groups()))
+            if python_version and sys.version_info < python_version:
+                continue
             match = SELFTEST_REGEX.match(line)
             if match is None:
                 continue

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py27, py34, py35, py36, py37, py38, pypy, pypy3, jython
+envlist = py27, py34, py35, py36, py37, py38, py39, py310, pypy, pypy3, jython
 skip_missing_interpreters = True
 
 [testenv]


### PR DESCRIPTION
`E271 multiple spaces after keyword` and `E275 missing whitespace after keyword` should also also be emitted for `match` and `case`. However, since they are only soft keywords, some additional logic is needed.

If accepted and the next version is released, this check could be added to flake8 as well ([flake8/setup.cfg](https://github.com/PyCQA/flake8/blob/7a371265cf876736b8d03907df26b813874b4201/setup.cfg#L72-L74)).