### PR TITLE
Small fix to version_info comparison

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -822,7 +822,7 @@ def whitespace_before_parameters(logical_line, tokens):
             not keyword.iskeyword(prev_text) and
             # 'match' and 'case' are only soft keywords
             (
-                sys.version_info < (3, 10) or
+                sys.version_info < (3, 9) or
                 not keyword.issoftkeyword(prev_text)
             )
         ):

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -822,7 +822,7 @@ def whitespace_before_parameters(logical_line, tokens):
             not keyword.iskeyword(prev_text) and
             # 'match' and 'case' are only soft keywords
             (
-                sys.version_info <= (3, 10) or
+                sys.version_info < (3, 10) or
                 not keyword.issoftkeyword(prev_text)
             )
         ):


### PR DESCRIPTION
Small issue I missed for #989. Technically this isn't a problem since even the alpha versions are `> (3, 10)`

/CC: @asottile 