### PR TITLE
add performance hack to improve tokenize speed

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -78,6 +78,13 @@ try:
 except ImportError:
     from ConfigParser import RawConfigParser
 
+# this is a performance hack.  see https://bugs.python.org/issue43014
+if (
+        sys.version_info < (3, 10) and
+        callable(getattr(tokenize, '_compile', None))
+):  # pragma: no cover (<py310)
+    tokenize._compile = lru_cache()(tokenize._compile)  # type: ignore
+
 __version__ = '2.7.0'
 
 DEFAULT_EXCLUDE = '.svn,CVS,.bzr,.hg,.git,__pycache__,.tox'


### PR DESCRIPTION
in profiles, this attributed somewhere between 4% and 14% of pycodestyle's execution time

this is committed upstream in cpython 3.10, I've also used this to get pretty significant performance boosts in my formatter tools which are based on [tokenize-rt](https://github.com/asottile/tokenize-rt/blob/6911895baaf8e8c309c112d43e54f58a1f17efdd/tokenize_rt.py#L16-L22)