### PR TITLE
pycodestyle --statistics for E501 reports the longest line

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -2340,7 +2340,6 @@ class BaseReport(object):
             self.messages['E501'] = 'line too long (%d > %d characters)' % (
                 _longest_line, self._max_line_length
             )
-
         return ['%-7s %s %s' % (self.counters[key], key, self.messages[key])
                 for key in sorted(self.messages) if key.startswith(prefix)]
 


### PR DESCRIPTION
When I run pycodestyle on a new codebase, I want to know what I should set `--max-line-length` to be so that new code changes do not make the line length problem worse.  I currently need to scan the verbose output and manually search the E501 messages for the longest line and then run `pycodestyle --max-line-length=97` to see if I found the maximum value.  If I did not (often happens), then I need to rinse and repeat.  This is both error-prone and frustrating so, what if the E501 message of `pycodestyle --statistics` _always_ showed me the length of the longest line?  This PR makes that happen!