### PR TITLE
WiP: Added PEP518 support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -56,6 +56,14 @@ You can install, upgrade, and uninstall ``pycodestyle.py`` with these commands::
 There's also a package for Debian/Ubuntu, but it's not always the
 latest version.
 
+If you want to use a PEP518 compliant ``pyproject.toml`` for configuration you must
+install the pep518 extra::
+
+  $ pip install pycodestyle[pep518]
+
+In this case, you can add a ``[tool.pycodestyle]`` configuration section in your
+``pyproject.toml`` file instead of using ``tox.ini`` or ``setup.cfg``.
+
 Example usage and output
 ------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,9 @@ setup(
         # Broken with Python 3: https://github.com/pypa/pip/issues/650
         # 'setuptools',
     ],
+    extras_require={
+        'pep518': ['toml>=0.10.2']
+    },
     entry_points={
         'console_scripts': [
             'pycodestyle = pycodestyle:_main',


### PR DESCRIPTION
The PIP518 support as described in
https://github.com/PyCQA/pycodestyle/issues/813
has been implemented roughly.

It uses the toml package, since the toml package describes itself as
being Python 2 compatible.
Using another package will create  a dependency that
might not be wanted. Hence the dependency is
treated optional as an extra, so consumers can decide
which revision they would like to use.

TODO: Unit test must be written explicitely.