### PR TITLE
Issue #588: E201: detect tabs as whitespace

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -144,7 +144,7 @@ RAISE_COMMA_REGEX = re.compile(r'raise\s+\w+\s*,')
 RERAISE_COMMA_REGEX = re.compile(r'raise\s+\w+\s*,.*,\s*\w+\s*$')
 ERRORCODE_REGEX = re.compile(r'\b[A-Z]\d{3}\b')
 DOCSTRING_REGEX = re.compile(r'u?r?["\']')
-EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[\[({] | [\]}),;]| :(?!=)')
+EXTRANEOUS_WHITESPACE_REGEX = re.compile(r'[\[({][ \t]|[ \t][\]}),;:](?!=)')
 WHITESPACE_AFTER_COMMA_REGEX = re.compile(r'[,;:]\s*(?:  |\t)')
 COMPARE_SINGLETON_REGEX = re.compile(r'(\bNone|\bFalse|\bTrue)?\s*([=!]=)'
                                      r'\s*(?(1)|(None|False|True))\b')
@@ -471,7 +471,7 @@ def extraneous_whitespace(logical_line):
         text = match.group()
         char = text.strip()
         found = match.start()
-        if text == char + ' ':
+        if text[-1].isspace():
             # assert char in '([{'
             yield found + 1, "E201 whitespace after '%s'" % char
         elif line[found - 1] != ',':

--- a/testsuite/E20.py
+++ b/testsuite/E20.py
@@ -4,6 +4,12 @@ spam( ham[1], {eggs: 2})
 spam(ham[ 1], {eggs: 2})
 #: E201:1:15
 spam(ham[1], { eggs: 2})
+#: E201:1:6
+spam(	ham[1], {eggs: 2})
+#: E201:1:10
+spam(ham[	1], {eggs: 2})
+#: E201:1:15
+spam(ham[1], {	eggs: 2})
 #: Okay
 spam(ham[1], {eggs: 2})
 #:
@@ -15,6 +21,12 @@ spam(ham[1], {eggs: 2} )
 spam(ham[1], {eggs: 2 })
 #: E202:1:11
 spam(ham[1 ], {eggs: 2})
+#: E202:1:23
+spam(ham[1], {eggs: 2}	)
+#: E202:1:22
+spam(ham[1], {eggs: 2	})
+#: E202:1:11
+spam(ham[1	], {eggs: 2})
 #: Okay
 spam(ham[1], {eggs: 2})
 
@@ -39,13 +51,24 @@ result = [
 if x == 4 :
     print x, y
     x, y = y, x
+#: E203:1:10
+if x == 4	:
+    print x, y
+    x, y = y, x
 #: E203:2:15 E702:2:16
 if x == 4:
     print x, y ; x, y = y, x
+#: E203:2:15 E702:2:16
+if x == 4:
+    print x, y	; x, y = y, x
 #: E203:3:13
 if x == 4:
     print x, y
     x, y = y , x
+#: E203:3:13
+if x == 4:
+    print x, y
+    x, y = y	, x
 #: Okay
 if x == 4:
     print x, y


### PR DESCRIPTION
```
printf 'foo(\tbar)\n' | pycodestyle -
stdin:1:5: E201 whitespace after '('
```

Fixes #588