### PR TITLE
Add whitespace checks for `match` and `case` - 2nd attempt

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -488,6 +488,8 @@ def whitespace_around_keywords(logical_line, tokens):
                 return
             if match[1] == '':
                 yield match.start(1), "E275 missing whitespace after keyword"
+            elif '\t' in match[1]:
+                yield match.start(1), "E273 tab after keyword"
             else:
                 yield match.start(1), "E271 multiple spaces after keyword"
         else:
@@ -537,6 +539,8 @@ def whitespace_around_keywords(logical_line, tokens):
                     yield (
                         match.start(1), "E275 missing whitespace after keyword"
                     )
+                elif '\t' in match[1]:
+                    yield match.start(1), "E273 tab after keyword"
                 else:
                     yield match.start(1), "E271 multiple spaces after keyword"
 

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -148,6 +148,7 @@ STARTSWITH_INDENT_STATEMENT_REGEX = re.compile(
 )
 DUNDER_REGEX = re.compile(r"^__([^\s]+)__(?::\s*[a-zA-Z.0-9_\[\]\"]+)? = ")
 BLANK_EXCEPT_REGEX = re.compile(r"except\s*:")
+MATCH_CASE_REGEX = re.compile(r'^\s*\b(?:match|case)(\s*)(?=.*\:)')
 
 if sys.version_info >= (3, 12):  # pragma: >=3.12 cover
     FSTRING_START = tokenize.FSTRING_START
@@ -474,6 +475,16 @@ def whitespace_around_keywords(logical_line):
             yield match.start(2), "E273 tab after keyword"
         elif len(after) > 1:
             yield match.start(2), "E271 multiple spaces after keyword"
+
+    if sys.version_info >= (3, 10):
+        match = MATCH_CASE_REGEX.match(logical_line)
+        if match:
+            if match[1] == ' ':
+                return
+            if match[1] == '':
+                yield match.start(1), "E275 missing whitespace after keyword"
+            else:
+                yield match.start(1), "E271 multiple spaces after keyword"
 
 
 @register_check

--- a/testing/data/python310.py
+++ b/testing/data/python310.py
@@ -55,7 +55,7 @@ match var:
     case  {"x": 42}: pass
     case  [{"y": 2}, 3]: print()  # comment
     case  "Hello: World": pass
-#: E221:6:5 E221:7:5
+#: E221:6:5 E221:7:5 E221:9:9
 # Don't emit false-positives
 # Only E221 (multiple spaces before operator), not E271!
 match: int = 42
@@ -63,3 +63,7 @@ case: int = 42
 matched = {"true": True, "false": False}
 case  = {"x": 42}
 case  = "Hello: World"
+if (
+    case  := 42
+):
+    pass

--- a/testing/data/python310.py
+++ b/testing/data/python310.py
@@ -22,6 +22,10 @@ match var:
         pass
     case (0, 1, *_):
         pass
+    case {"x": 42}:
+        pass
+    case SomeClass(arg=2):
+        pass
 #: E271:2:6 E271:3:9 E271:5:9 E271:7:9
 var = 1
 match  var:
@@ -40,3 +44,20 @@ match(var):
         pass
     case_:
         pass
+#: E271:2:9 E271:3:9 E271:6:9 E271:7:9 E271:8:9
+match var:
+    case  (2, 3): pass
+    case  (
+        2, 3
+    ): pass
+    case  {"x": 42}: pass
+    case  [{"y": 2}, 3]: print()  # comment
+    case  "Hello: World": pass
+#: E221:6:5 E221:7:5
+# Don't emit false-positives
+# Only E221 (multiple spaces before operator), not E271!
+match: int = 42
+case: int = 42
+matched = {"true": True, "false": False}
+case  = {"x": 42}
+case  = "Hello: World"

--- a/testing/data/python310.py
+++ b/testing/data/python310.py
@@ -22,3 +22,21 @@ match var:
         pass
     case (0, 1, *_):
         pass
+#: E271:2:6 E271:3:9 E271:5:9 E271:7:9
+var = 1
+match  var:
+    case  1:
+        pass
+    case	2:
+        pass
+    case  (
+        3
+    ):
+        pass
+#: E275:2:6 E275:3:9 E275:5:9
+var = 1
+match(var):
+    case(1):
+        pass
+    case_:
+        pass

--- a/testing/data/python310.py
+++ b/testing/data/python310.py
@@ -26,16 +26,18 @@ match var:
         pass
     case SomeClass(arg=2):
         pass
-#: E271:2:6 E271:3:9 E271:5:9 E271:7:9
+#: E271:2:6 E271:3:9 E271:5:9
 var = 1
 match  var:
     case  1:
         pass
-    case	2:
-        pass
     case  (
         3
     ):
+        pass
+#: E273:1:6 E273:2:9
+match	var:
+    case	2:
         pass
 #: E275:2:6 E275:3:9 E275:5:9
 var = 1


### PR DESCRIPTION
Second attempt after #990

I've improved the default `MATCH_CASE_REGEX`, especially the lookahead part.
```diff
- (?=.*\:)
+ (?=.*\S.*\:(?=\s*$|\s*#))
```
It now requires at least one non-whitespace char to be present between `case` and `:`. Furthermore it matches end of line or begin of comment.

To account for case statements written inline, I've added fallback logic. That uses the tokenizer to check the `:` isn't inside any brackets.
```py
match 0:
    case _: print('hi')
    case {"x": 42}: pass
    case "Hello: World": pass
```