### PR TITLE
fix E721 types regex

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -144,8 +144,10 @@ COMPARE_SINGLETON_REGEX = re.compile(r'(\bNone|\bFalse|\bTrue)?\s*([=!]=)'
                                      r'\s*(?(1)|(None|False|True))\b')
 COMPARE_NEGATIVE_REGEX = re.compile(r'\b(?<!is\s)(not)\s+[^][)(}{ ]+\s+'
                                     r'(in|is)\s')
-COMPARE_TYPE_REGEX = re.compile(r'(?:[=!]=|is(?:\s+not)?)\s+type(?:s.\w+Type'
-                                r'|\s*\(\s*([^)]*[^ )])\s*\))')
+COMPARE_TYPE_REGEX = re.compile(
+    r'(?:[=!]=|is(?:\s+not)?)\s+type(?:\s*\(\s*([^)]*[^ )])\s*\))' +
+    r'|type(?:\s*\(\s*([^)]*[^ )])\s*\))\s+(?:[=!]=|is(?:\s+not)?)'
+)
 KEYWORD_REGEX = re.compile(r'(\s*)\b(?:%s)\b(\s*)' % r'|'.join(KEYWORDS))
 OPERATOR_REGEX = re.compile(r'(?:[^,\s])(\s*)(?:[-+*/|!<=>%&^]+|:=)(\s*)')
 LAMBDA_REGEX = re.compile(r'\blambda\b')

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1465,7 +1465,6 @@ def comparison_type(logical_line, noqa):
     common base class, basestring, so you can do:
 
     Okay: if isinstance(obj, basestring):
-    Okay: if type(a1) is type(b1):
     """
     match = COMPARE_TYPE_REGEX.search(logical_line)
     if match and not noqa:

--- a/testsuite/E72.py
+++ b/testsuite/E72.py
@@ -80,3 +80,8 @@ try:
     pass
 except Exception:
     pass
+#: Okay
+from . import custom_types as types
+
+red = types.ColorTypeRED
+red is types.ColorType.RED

--- a/testsuite/E72.py
+++ b/testsuite/E72.py
@@ -4,7 +4,7 @@ if type(res) == type(42):
 #: E721
 if type(res) != type(""):
     pass
-#: E721
+#: Okay
 import types
 
 if res == types.IntType:
@@ -46,8 +46,6 @@ if isinstance(res, int):
 if isinstance(res, str):
     pass
 if isinstance(res, types.MethodType):
-    pass
-if type(a) != type(b) or type(a) == type(ccc):
     pass
 #: Okay
 def func_histype(a, b, c):

--- a/testsuite/custom_types.py
+++ b/testsuite/custom_types.py
@@ -1,7 +1,0 @@
-import enum
-
-
-class ColorType(enum.Enum):
-    RED = 1
-    GREEN = 2
-    BLUE = 3

--- a/testsuite/custom_types.py
+++ b/testsuite/custom_types.py
@@ -1,0 +1,7 @@
+import enum
+
+
+class ColorType(enum.Enum):
+    RED = 1
+    GREEN = 2
+    BLUE = 3


### PR DESCRIPTION
tl;dr [The PEP8 example for the issue][0] only includes the `type(a) == type(b)` comparison, it does not include the `== types.SomeType` issue, the latter should not be handled under this error check.

This check was introduced to trunk following issue #47, and I believe it _incorrectly_ borrowed the example from the issue literally. The E721 check was since reported on a few false-positive issues and then expanded a number of times to handle those around types (see 034b9f4fb082f72e1087a8a27dd0dd61486d1888 and 0327e55e756e20ade468e67992f9f43da14aabb4).

I believe the behaviour should change because object comparison cannot be confirmed a "type comparison" in the same sense; not without having additional information, which is not possible with regex alone (_maybe_ with AST analysis).
This check also breaks many ligimitate cases (such as having your own types module with an Enum class for instance, and comparing a value to the  enum member).
If the community wants to keep it, I strongly advise it be made a separate warning level advisory (W###) rather than overloading E721, so we can handle any logic around it separately.

For reference, I learned more about the pattern, and tested for the cases using regexr:
* Original pattern - https://regexr.com/6bc9t
* Fixed pattern - https://regexr.com/6bca0

fixes issue #830

[0]: https://www.python.org/dev/peps/pep-0008/#programming-recommendations