### PR TITLE
docs: Fix double-dash converted to en-dash

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -432,7 +432,7 @@ This is the current list of error and warning codes:
 **(*)** In the default configuration, the checks **E121**, **E123**, **E126**, **E133**,
 **E226**, **E241**, **E242**, **E704**, **W503**, **W504** and **W505** are ignored
 because they are not rules unanimously accepted, and `PEP 8`_ does not enforce them.
-Please note that if the option **--ignore=errors** is used,
+Please note that if the option ``--ignore=errors`` is used,
 the default configuration will be overridden and ignore only the check(s) you skip.
 The check **W503** is mutually exclusive with check **W504**.
 The check **E133** is mutually exclusive with check **E123**.  Use switch


### PR DESCRIPTION
The double-dash for command line option `--ignore` was being converted to an en-dash.

I'm not very familiar with RST, but this change seems correct. By all means reject if not.

Same change as PyCQA/pydocstyle/pull/579