### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,9 @@ setup(
     maintainer='Ian Lee',
     maintainer_email='IanLee1521@gmail.com',
     url='https://pycodestyle.pycqa.org/',
+    project_urls={
+        'Source': 'https://github.com/PyCQA/pycodestyle',
+    },
     license='Expat license',
     py_modules=['pycodestyle'],
     include_package_data=True,


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.