### PR TITLE
Generalize E275 to require space after all keywords, not just "import".

### DIFF
--- a/testsuite/E12not.py
+++ b/testsuite/E12not.py
@@ -40,8 +40,8 @@ a = (123,
 
 if start[1] > end_col and not (
         over_indent == 4 and indent_next):
-    return(0, "E121 continuation line over-"
-           "indented for visual indent")
+    return (0, "E121 continuation line over-"
+            "indented for visual indent")
 
 
 print "OK", ("visual",
@@ -175,7 +175,7 @@ fooff(aaaa,
 #
 
 if bar:
-    return(
+    return (
         start, 'E121 lines starting with a '
         'closing bracket should be indented '
         "to match that of the opening "

--- a/testsuite/E27.py
+++ b/testsuite/E27.py
@@ -42,5 +42,10 @@ try:
     from importable.module import(e, f)
 except ImportError:
     pass
+#: E275
+if(foo):
+    pass
+else:
+    pass
 #: Okay
 matched = {"true": True, "false": False}

--- a/testsuite/W19.py
+++ b/testsuite/W19.py
@@ -41,8 +41,8 @@ if (
 #: E101 E101 W191 W191
 if start[1] > end_col and not (
         over_indent == 4 and indent_next):
-	return(0, "E121 continuation line over-"
-	       "indented for visual indent")
+	return (0, "E121 continuation line over-"
+	        "indented for visual indent")
 #:
 
 #: E101 W191
@@ -58,7 +58,7 @@ if ((row < 0 or self.moduleCount <= row or
 	raise Exception("%s,%s - %s" % (row, col, self.moduleCount))
 #: E101 E101 E101 E101 W191 W191 W191 W191 W191 W191
 if bar:
-	return(
+	return (
 	    start, 'E121 lines starting with a '
 	    'closing bracket should be indented '
 	    "to match that of the opening "


### PR DESCRIPTION
The error message was worded to cover more cases, so I just reused E275 here; I can also add a new error code instead if you prefer.
Partially addresses #371 (only the "space required after keyword" part, not the "space required before keyword" part).