### PR TITLE
allow `is` and `is not` for type comparisons (E721)

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -129,8 +129,8 @@ COMPARE_SINGLETON_REGEX = re.compile(r'(\bNone|\bFalse|\bTrue)?\s*([=!]=)'
 COMPARE_NEGATIVE_REGEX = re.compile(r'\b(?<!is\s)(not)\s+[^][)(}{ ]+\s+'
                                     r'(in|is)\s')
 COMPARE_TYPE_REGEX = re.compile(
-    r'(?:[=!]=|is(?:\s+not)?)\s+type(?:\s*\(\s*([^)]*[^ )])\s*\))' +
-    r'|\btype(?:\s*\(\s*([^)]*[^ )])\s*\))\s+(?:[=!]=|is(?:\s+not)?)'
+    r'[=!]=\s+type(?:\s*\(\s*([^)]*[^ )])\s*\))'
+    r'|\btype(?:\s*\(\s*([^)]*[^ )])\s*\))\s+[=!]='
 )
 KEYWORD_REGEX = re.compile(r'(\s*)\b(?:%s)\b(\s*)' % r'|'.join(KEYWORDS))
 OPERATOR_REGEX = re.compile(r'(?:[^,\s])(\s*)(?:[-+*/|!<=>%&^]+|:=)(\s*)')
@@ -1459,7 +1459,7 @@ def comparison_type(logical_line, noqa):
     Do not compare types directly.
 
     Okay: if isinstance(obj, int):
-    E721: if type(obj) is type(1):
+    E721: if type(obj) == type(1):
     """
     match = COMPARE_TYPE_REGEX.search(logical_line)
     if match and not noqa:

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -128,8 +128,10 @@ COMPARE_SINGLETON_REGEX = re.compile(r'(\bNone|\bFalse|\bTrue)?\s*([=!]=)'
                                      r'\s*(?(1)|(None|False|True))\b')
 COMPARE_NEGATIVE_REGEX = re.compile(r'\b(?<!is\s)(not)\s+[^][)(}{ ]+\s+'
                                     r'(in|is)\s')
-COMPARE_TYPE_REGEX = re.compile(r'(?:[=!]=|is(?:\s+not)?)\s+type(?:s.\w+Type'
-                                r'|\s*\(\s*([^)]*[^ )])\s*\))')
+COMPARE_TYPE_REGEX = re.compile(
+    r'(?:[=!]=|is(?:\s+not)?)\s+type(?:\s*\(\s*([^)]*[^ )])\s*\))' +
+    r'|\btype(?:\s*\(\s*([^)]*[^ )])\s*\))\s+(?:[=!]=|is(?:\s+not)?)'
+)
 KEYWORD_REGEX = re.compile(r'(\s*)\b(?:%s)\b(\s*)' % r'|'.join(KEYWORDS))
 OPERATOR_REGEX = re.compile(r'(?:[^,\s])(\s*)(?:[-+*/|!<=>%&^]+|:=)(\s*)')
 LAMBDA_REGEX = re.compile(r'\blambda\b')
@@ -1458,13 +1460,6 @@ def comparison_type(logical_line, noqa):
 
     Okay: if isinstance(obj, int):
     E721: if type(obj) is type(1):
-
-    When checking if an object is a string, keep in mind that it might
-    be a unicode string too! In Python 2.3, str and unicode have a
-    common base class, basestring, so you can do:
-
-    Okay: if isinstance(obj, basestring):
-    Okay: if type(a1) is type(b1):
     """
     match = COMPARE_TYPE_REGEX.search(logical_line)
     if match and not noqa:

--- a/testsuite/E72.py
+++ b/testsuite/E72.py
@@ -9,7 +9,7 @@ import types
 
 if res == types.IntType:
     pass
-#: E721
+#: Okay
 import types
 
 if type(res) is not types.ListType:
@@ -26,9 +26,9 @@ assert type(res) == type((0,))
 assert type(res) == type((0))
 #: E721
 assert type(res) != type((1, ))
-#: E721
+#: Okay
 assert type(res) is type((1, ))
-#: E721
+#: Okay
 assert type(res) is not type((1, ))
 #: E211 E721
 assert type(res) == type ([2, ])

--- a/testsuite/E72.py
+++ b/testsuite/E72.py
@@ -4,7 +4,7 @@ if type(res) == type(42):
 #: E721
 if type(res) != type(""):
     pass
-#: E721
+#: Okay
 import types
 
 if res == types.IntType:
@@ -47,8 +47,6 @@ if isinstance(res, str):
     pass
 if isinstance(res, types.MethodType):
     pass
-if type(a) != type(b) or type(a) == type(ccc):
-    pass
 #: Okay
 def func_histype(a, b, c):
     pass
@@ -80,6 +78,11 @@ try:
     pass
 except Exception:
     pass
+#: Okay
+from . import custom_types as types
+
+red = types.ColorTypeRED
+red is types.ColorType.RED
 #: Okay
 from . import compute_type
 


### PR DESCRIPTION
see #1084 and #1041 for more details

resolves #1084 
resolves #830