### PR TITLE
run testsuite with pytest

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,11 +11,12 @@ skip_missing_interpreters = True
 deps =
     covdefaults
     coverage
+    pytest
 commands =
     python -m pycodestyle --statistics pycodestyle.py
     coverage run -m pycodestyle --max-doc-length=72 --testsuite testing/data
     coverage run -m pycodestyle --max-doc-length=72 --doctest
-    coverage run -m unittest discover testsuite -vv
+    coverage run -m pytest testsuite
     coverage combine
     coverage report
 


### PR DESCRIPTION
planning to make the self tests easier to run / more repeatable without needing the whole testsuite run

going to remove most of the custom testsuite code we have and use pytest parameterization instead