### PR TITLE
testing: add a pair of E303 testcases

### DIFF
--- a/testing/data/E30.py
+++ b/testing/data/E30.py
@@ -75,6 +75,20 @@ def a():
 #:
 
 
+#: E303:6:5
+class xyz:
+    def a(self):
+        pass
+
+
+    def b(self):
+        pass
+#: E303:5:5
+if True:
+    a = 1
+
+
+    a = 2
 #: E304:3:1
 @decorator
 


### PR DESCRIPTION
Add two test cases to verify that pycodestyle correctly flags 2 empty lines in non-toplevel contexts, even outside of functions: one for two empty lines between class methods and one for two empty lines in the indented body of an `if:` statement at toplevel.

The motivation here is to resolve ambiguity about the intended behaviour of this rule.  See https://github.com/astral-sh/ruff/pull/8720#issuecomment-1817837253.