### PR TITLE
Adds support for pyproject.toml for python 3.11+ projects

### DIFF
--- a/docs/intro.rst
+++ b/docs/intro.rst
@@ -200,7 +200,8 @@ Example::
   max-line-length = 160
   statistics = True
 
-At the project level, a ``setup.cfg`` file or a ``tox.ini`` file is read if
+At the project level, a ``setup.cfg`` file or a ``tox.ini``
+(or a ``pyproject.toml`` if running python 3.11+) file is read if
 present. If none of these files have a ``[pycodestyle]`` section, no project
 specific configuration is loaded.
 

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -60,6 +60,8 @@ import warnings
 from fnmatch import fnmatch
 from functools import lru_cache
 from optparse import OptionParser
+if sys.version_info >= (3, 11):
+    import tomllib
 
 # this is a performance hack.  see https://bugs.python.org/issue43014
 if (
@@ -83,7 +85,11 @@ try:
 except ImportError:
     USER_CONFIG = None
 
-PROJECT_CONFIG = ('setup.cfg', 'tox.ini')
+if sys.version_info >= (3, 11):
+    PROJECT_CONFIG = ('setup.cfg', 'tox.ini', 'pyproject.toml')
+else:
+    PROJECT_CONFIG = ('setup.cfg', 'tox.ini')
+
 MAX_LINE_LENGTH = 79
 # Number of blank lines between various code parts.
 BLANK_LINES_CONFIG = {

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -60,8 +60,6 @@ import warnings
 from fnmatch import fnmatch
 from functools import lru_cache
 from optparse import OptionParser
-if sys.version_info >= (3, 11):
-    import tomllib
 
 # this is a performance hack.  see https://bugs.python.org/issue43014
 if (
@@ -2500,7 +2498,6 @@ def read_config(options, args, arglist, parser):
     ConfigParser.
     """
     config = configparser.RawConfigParser()
-
     cli_conf = options.config
 
     local_dir = os.curdir


### PR DESCRIPTION
PEP 518 and PEP 621 have standardized the use of pyproject.toml for specifying build system requirements and project metadata.  Now that python 3.11 has a toml parsing library, and especially because it's baked right into configparser, it is the right time to give the python community what it has been asking for, and include pyproject as a configuration option.