### PR TITLE
prevent false positive for E721 on member function

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -127,7 +127,7 @@ COMPARE_NEGATIVE_REGEX = re.compile(r'\b(?<!is\s)(not)\s+[^][)(}{ ]+\s+'
                                     r'(in|is)\s')
 COMPARE_TYPE_REGEX = re.compile(
     r'[=!]=\s+type(?:\s*\(\s*([^)]*[^\s)])\s*\))'
-    r'|\btype(?:\s*\(\s*([^)]*[^\s)])\s*\))\s+[=!]='
+    r'|(?<!\.)\btype(?:\s*\(\s*([^)]*[^\s)])\s*\))\s+[=!]='
 )
 KEYWORD_REGEX = re.compile(r'(\s*)\b(?:%s)\b(\s*)' % r'|'.join(KEYWORDS))
 OPERATOR_REGEX = re.compile(r'(?:[^,\s])(\s*)(?:[-+*/|!<=>%&^]+|:=)(\s*)')

--- a/testing/data/E72.py
+++ b/testing/data/E72.py
@@ -5,6 +5,8 @@ if type(res) == type(42):
 if type(res) != type(""):
     pass
 #: Okay
+res.type("") == ""
+#: Okay
 import types
 
 if res == types.IntType:


### PR DESCRIPTION
E721 was reported on the result of member functions of name "type" with one parameter, if those occurred on the left side of an equality operator comparison.