### PR TITLE
E502: Fix E502 being disabled after a comment in a logical line

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1269,6 +1269,8 @@ def explicit_line_join(logical_line, tokens):
             comment = True
         if start[0] != prev_start and parens and backslash and not comment:
             yield backslash, "E502 the backslash is redundant between brackets"
+        if start[0] != prev_start:
+            comment = False  # Reset comment flag on newline
         if end[0] != prev_end:
             if line.rstrip('\r\n').endswith('\\'):
                 backslash = (end[0], len(line.splitlines()[-1]) - 1)

--- a/testing/data/E50.py
+++ b/testing/data/E50.py
@@ -25,6 +25,13 @@ a = ('AAA  \
 if (foo is None and bar is "e000" and \
         blah == 'yeah'):
     blah = 'yeahnah'
+#: E502 W503 W503
+y = (
+    2 + 2  # \
+    + 3  # \
+    + 4 \
+    + 3
+)
 #
 #: Okay
 a = ('AAA'


### PR DESCRIPTION
Since the comment flag was being set and then never disabled in the `explicit_line_join` implementation, any redundant backslash which occured after the first comment in a logical line would go undetected. e.g.
```
y = (
    2 + 2  # \
    + 3  # \
    + 4 \
    + 3
)
```
would not detect the redundant backslash after the 4.