### PR TITLE
Use list comprehensions to avoid append() calls

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1910,9 +1910,7 @@ class Checker:
 
     def run_check(self, check, argument_names):
         """Run a check plugin."""
-        arguments = []
-        for name in argument_names:
-            arguments.append(getattr(self, name))
+        arguments = [getattr(self, name) for name in argument_names]
         return check(*arguments)
 
     def init_checker_state(self, name, argument_names):


### PR DESCRIPTION
This provides a small speed-up on large codebases (~80ms).

## Stats

### Before

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
 12900025    2.590    0.000    2.590    0.000 {method 'append' of 'list' objects}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pycodestyle .` | 18.178 ± 0.198 | 17.951 | 18.666 | 1.00 |


### After

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  4457822    1.049    0.000    1.049    0.000 {method 'append' of 'list' objects}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pycodestyle .` | 18.099 ± 0.132 | 17.887 | 18.346 | 1.00 |


## Set-up
I profiled pycodestyle with the yt-dlp codebase because it is similar in composition to a private codebase I have.

```shell
git clone https://github.com/yt-dlp/yt-dlp.git
cd yt-dlp

git checkout ef36d517f9b05785d61abca7691d9ab7d63cc75c

# Callgraph command
python -m cProfile -o stats $(which pycodestyle)

# Benchmarking command
hyperfine --ignore-failure --warmup 2 --runs 10 --export-markdown=baseline.md 'pycodestyle .'
```

**setup.cfg**
```
[pycodestyle]
ignore = W504
max-line-length = 100
```