### PR TITLE
Combine rstrip calls in trailing_whitespace check

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -233,9 +233,11 @@ def trailing_whitespace(physical_line):
     W291: spam(1) \n#
     W293: class Foo(object):\n    \n    bang = 12
     """
-    physical_line = physical_line.rstrip('\n')    # chr(10), newline
-    physical_line = physical_line.rstrip('\r')    # chr(13), carriage return
-    physical_line = physical_line.rstrip('\x0c')  # chr(12), form feed, ^L
+    # Strip these trailing characters:
+    # - chr(10), newline
+    # - chr(13), carriage return
+    # - chr(12), form feed, ^L
+    physical_line = physical_line.rstrip('\n\r\x0c')
     stripped = physical_line.rstrip(' \t\v')
     if physical_line != stripped:
         if stripped:


### PR DESCRIPTION
This provides a small speed-up on large codebases (~90ms).

## Stats

### Before

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1609756    0.432    0.000    0.432    0.000 {method 'rstrip' of 'str' objects}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pycodestyle .` | 18.178 ± 0.198 | 17.951 | 18.666 | 1.00 |


### After

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1137564    0.311    0.000    0.311    0.000 {method 'rstrip' of 'str' objects}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pycodestyle .` | 18.090 ± 0.155 | 17.784 | 18.264 | 1.00 |


## Set-up
I profiled pycodestyle with the yt-dlp codebase because it is similar in composition to a private codebase I have.

```shell
git clone https://github.com/yt-dlp/yt-dlp.git
cd yt-dlp

git checkout ef36d517f9b05785d61abca7691d9ab7d63cc75c

# Callgraph command
python -m cProfile -o stats $(which pycodestyle)

# Benchmarking command
hyperfine --ignore-failure --warmup 2 --runs 10 --export-markdown=baseline.md 'pycodestyle .'
```

**setup.cfg**
```
[pycodestyle]
ignore = W504
max-line-length = 100
```