### PR TITLE
Speed up _is_eol_token

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1829,7 +1829,15 @@ def update_counts(s, counts):
 
 
 def _is_eol_token(token):
-    return token[0] in NEWLINE or token[4][token[3][1]:].lstrip() == '\\\n'
+    if token[0] in NEWLINE:
+        return True
+
+    # Check if the line's penultimate character is a continuation
+    # character
+    if token[4][-2] != '\\':
+        return False
+
+    return token[4][token[3][1]:].lstrip() == '\\\n'
 
 
 ########################################################################


### PR DESCRIPTION
This change provides a small speed-up on large codebases (~200ms).

## Stats

### Before

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1478156    0.940    0.000    1.245    0.000 pycodestyle.py:1831(_is_eol_token)
  1472360    0.359    0.000    0.359    0.000 {method 'lstrip' of 'str' objects}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pycodestyle .` | 18.349 ± 0.161 | 18.119 | 18.641 | 1.00 |



### After

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1478156    0.458    0.000    0.459    0.000 pycodestyle.py:1831(_is_eol_token)
   225341    0.057    0.000    0.057    0.000 {method 'lstrip' of 'str' objects}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pycodestyle .` | 18.145 ± 0.098 | 17.997 | 18.283 | 1.00 |


## Set-up
I profiled pycodestyle with the yt-dlp codebase because it is similar in composition to a private codebase I have.

```shell
git clone https://github.com/yt-dlp/yt-dlp.git
cd yt-dlp

git checkout ef36d517f9b05785d61abca7691d9ab7d63cc75c

# Callgraph command
python -m cProfile -o stats $(which pycodestyle)

# Benchmarking command
hyperfine --ignore-failure --warmup 2 --runs 15 --export-markdown=baseline.md 'pycodestyle .'
```

**setup.cfg**
```
[pycodestyle]
ignore = W504
max-line-length = 100
```

Baseline version: c8e36a0614c8ed2d1c4bd340f16eb5f5268b19e9