### PR TITLE
Speed up _is_eol_token

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1829,7 +1829,18 @@ def update_counts(s, counts):
 
 
 def _is_eol_token(token):
-    return token[0] in NEWLINE or token[4][token[3][1]:].lstrip() == '\\\n'
+    if token[0] in NEWLINE:
+        return True
+
+    if token[0] == tokenize.ENDMARKER:
+        return False
+
+    # Check if the line's penultimate character is a continuation
+    # character
+    if token[4][-2] != '\\':
+        return False
+
+    return token[4][token[3][1]:].lstrip() == '\\\n'
 
 
 ########################################################################


### PR DESCRIPTION
Continuation of #1256 because I force pushed and cannot reopen that PR. (Sorry for the noise.)

If this PR seems too risky because of assumptions about tokenization, feel free to pass!

## Stats

### Before

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1478156    0.885    0.000    1.197    0.000 pycodestyle.py:1831(_is_eol_token)
  1472360    0.364    0.000    0.364    0.000 {method 'lstrip' of 'str' objects}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pycodestyle .` | 18.472 ± 0.196 | 18.067 | 18.848 | 1.00 |


### After

```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
  1478156    0.511    0.000    0.511    0.000 pycodestyle.py:1831(_is_eol_token)
   225341    0.055    0.000    0.055    0.000 {method 'lstrip' of 'str' objects}
```

| Command | Mean [s] | Min [s] | Max [s] | Relative |
|:---|---:|---:|---:|---:|
| `pycodestyle .` | 18.360 ± 0.186 | 18.159 | 18.781 | 1.00 |
