### PR TITLE
Fix 868

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1196,9 +1196,11 @@ def module_imports_on_top_of_file(
 
 def _use_ast_to_check_for_lambda_assignment(logical_line):
     """Check if the line contains a lambda assignment."""
+    if not logical_line:
+        return False
     try:
         tree = ast.parse(logical_line)
-    except SyntaxError:
+    except (SyntaxError, ValueError):
         return False
     for node in ast.walk(tree):
         if isinstance(node, ast.Assign):

--- a/testing/data/E73.py
+++ b/testing/data/E73.py
@@ -1,5 +1,9 @@
 #: E731:1:1
 f = lambda x: 2 * x
+#: E731:1:1
+f = (  # some long comment that forces this to be on a new line
+    lambda x: 731 * x
+)
 #: E731:1:1 E226:1:16
 f = lambda x: 2*x
 #: E731:2:5
@@ -8,6 +12,13 @@ while False:
 #: Okay
 f = object()
 f.method = lambda: 'Method'
+
+f = (lambda o: o.lower()) if isinstance('a', str) else (lambda o: o)
+
+f = (
+    lambda o: o.lower(),
+    lambda o: o.upper(),
+)
 
 f = {}
 f['a'] = lambda x: x ** 2


### PR DESCRIPTION
The current string based search for E731 (assignment of lambda to variable) relies on a text search. This breaks down if the lambda has a comment stored on it forcing a multi-line assignment in the form of:
```python
f = (  # some long comment that forces this to be on a new line
    lambda x: 731 * x
)
```

However, existing tests indicate that 
```python
f = (lambda o: o.lower()) if isinstance('a', str) else (lambda o: o)
# and
f = (
    lambda o: o.lower(),
    lambda o: o.upper(),
)
```

Should be considered acceptable, so merely stripping off paranthesis before evaluating would not work.

# Implementation
By loading the "line" (in this example, `logical_line` comes in as `f = (lambda x: 731 * x)`) using the AST parser, we are able to check if there is an assignment of a Lambda to a Name. 

This allows all existing tests to pass while also resolving the new tests for E731.

Fixes #868