### PR TITLE
E721: flag swapped type comparisons like `int == type(obj)`

### DIFF
--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -121,8 +121,8 @@ COMPARE_SINGLETON_REGEX = re.compile(r'(\bNone|\bFalse|\bTrue)?\s*([=!]=)'
 COMPARE_NEGATIVE_REGEX = re.compile(r'\b(?<!is\s)(not)\s+[^][)(}{ ]+\s+'
                                     r'(in|is)\s')
 COMPARE_TYPE_REGEX = re.compile(
-    r'[=!]=\s+type(?:\s*\(\s*([^)]*[^\s)])\s*\))'
-    r'|(?<!\.)\btype(?:\s*\(\s*([^)]*[^\s)])\s*\))\s+[=!]='
+    r'[=!]=\s+type(?:\s*\(\s*[^)]*[^\s)]\s*\))'
+    r'|(?<!\.)\btype(?:\s*\(\s*[^)]*[^\s)]\s*\))\s+[=!]='
 )
 KEYWORD_REGEX = re.compile(r'(\s*)\b(?:%s)\b(\s*)' % r'|'.join(KEYWORDS))
 OPERATOR_REGEX = re.compile(r'(?:[^,\s])(\s*)(?:[-+*/|!<=>%&^]+|:=)(\s*)')
@@ -1498,12 +1498,11 @@ def comparison_type(logical_line, noqa):
     Okay: if isinstance(obj, int):
     Okay: if type(obj) is int:
     E721: if type(obj) == type(1):
+    E721: if type(obj) == int:
+    E721: if int == type(obj):
     """
     match = COMPARE_TYPE_REGEX.search(logical_line)
     if match and not noqa:
-        inst = match.group(1)
-        if inst and inst.isidentifier() and inst not in SINGLETONS:
-            return  # Allow comparison for types which are not obvious
         yield (
             match.start(),
             "E721 do not compare types, for exact checks use `is` / `is not`, "

--- a/testing/data/E72.py
+++ b/testing/data/E72.py
@@ -4,6 +4,12 @@ if type(res) == type(42):
 #: E721
 if type(res) != type(""):
     pass
+#: E721
+if int == type(res):
+    pass
+#: E721
+if str != type(res):
+    pass
 #: Okay
 res.type("") == ""
 #: Okay


### PR DESCRIPTION
## Summary

E721 (`do not compare types`) only fired when a `type(...)` call appeared on the **left** of `==` / `!=`:

```python
if type(obj) == int:   # E721
if int == type(obj):   # (nothing) — but this is the same comparison
```

`comparison_type` inspected only `match.group(1)` — the argument of the *right-hand* `type(...)` call — and suppressed the warning whenever that argument was a plain identifier (`if inst and inst.isidentifier() and inst not in SINGLETONS: return`). Because the two alternatives of `COMPARE_TYPE_REGEX` capture opposite operands, this made the check asymmetric: `type(obj) == x` was reported while the mirror `x == type(obj)` was not, and the issue's `int == type(obj)` slipped through entirely.

## Fix

Remove the identifier-based suppression so both operand orders are treated identically, and drop the now-unused capture groups from `COMPARE_TYPE_REGEX` (they are no longer referenced). The regex already matches a bare `type(...)` call on either side of `==` / `!=`, so the check is now symmetric.

No existing `Okay` fixture relied on the suppression — every one of them fails to match `COMPARE_TYPE_REGEX` in the first place (they use `is` / `is not`, `.type(`, `compute_type(`, or `types.SomeType`), so those cases are unaffected.

## Tests / Verification

- Added regression fixtures to `testing/data/E72.py` for the swapped `==` and `!=` forms (`if int == type(res):`, `if str != type(res):`), each annotated `#: E721`. These **fail on the pristine code** and pass with the fix.
- Added `E721` doctest examples to the `comparison_type` docstring (verified by `tests/test_self_doctests.py`).
- `pytest tests/` — all **777** tests pass.
- `pytest tests/test_data.py -k E72` — 26 fixture cases pass.
- `pre-commit run --files pycodestyle.py testing/data/E72.py` — all hooks (flake8, pyupgrade, reorder-python-imports, etc.) pass.
- Dog-food self-lint (`tests/test_all.py`) passes; running the CLI on the issue's repro now emits `E721`.

Fixes #1187.

Disclosure: prepared with AI assistance; reviewed and verified locally.
