### PR TITLE
E721: report reversed type comparisons

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+Unreleased
+----------
+
+Changes:
+
+* E721: also report reversed comparisons like ``int == type(obj)``.
+  Issue #1187.
+
 2.14.0 (2025-06-20)
 -------------------
 

--- a/pycodestyle.py
+++ b/pycodestyle.py
@@ -1498,12 +1498,12 @@ def comparison_type(logical_line, noqa):
     Okay: if isinstance(obj, int):
     Okay: if type(obj) is int:
     E721: if type(obj) == type(1):
+    E721: if type(obj) == int:
+    E721: if int == type(obj):
     """
     match = COMPARE_TYPE_REGEX.search(logical_line)
     if match and not noqa:
-        inst = match.group(1)
-        if inst and inst.isidentifier() and inst not in SINGLETONS:
-            return  # Allow comparison for types which are not obvious
+        # Flag both type(x) == T and T == type(x) (and !=).
         yield (
             match.start(),
             "E721 do not compare types, for exact checks use `is` / `is not`, "

--- a/testing/data/E72.py
+++ b/testing/data/E72.py
@@ -90,3 +90,12 @@ from . import compute_type
 
 if compute_type(foo) == 5:
     pass
+#: E721
+if type(obj) == int:
+    pass
+#: E721
+if int == type(obj):
+    pass
+#: E721
+if int != type(obj):
+    pass


### PR DESCRIPTION
## Summary

E721 already caught `type(obj) == int` but not the reversed form `int == type(obj)`, because `comparison_type` returned early when the first capture group (type on the right of `==`/`!=`) was a plain identifier.

This drops that early return so both comparison orders are reported. Allowed exact checks remain `type(x) is T` / `is not`, and instance checks stay `isinstance()`.

Fixes #1187

## Test plan

- [x] Added reversed cases to `testing/data/E72.py`
- [x] `pytest tests/ testing/ -q` → 767 passed, 11 skipped
